### PR TITLE
Fr5biomarker template selection fix

### DIFF
--- a/ramutils/test/test_data/R1354E_26OCT2017L0M0STIM.csv
+++ b/ramutils/test/test_data/R1354E_26OCT2017L0M0STIM.csv
@@ -1,0 +1,273 @@
+ODINConfigurationVersion:,#1.2#
+ConfigurationName:,26OCT2017L0M0STIM
+SubjectID:,R1354E
+Contacts:
+1Ld1,1,1,6.1839,#Electrode A-CH01 jack box 1#
+1Ld2,2,2,6.1839,#Electrode A-CH02 jack box 2#
+1Ld3,3,3,6.1839,#Electrode A-CH03 jack box 3#
+1Ld4,4,4,6.1839,#Electrode A-CH04 jack box 4#
+1Ld5,5,5,6.1839,#Electrode A-CH05 jack box 5#
+1Ld6,6,6,6.1839,#Electrode A-CH06 jack box 6#
+1Ld7,7,7,6.1839,#Electrode A-CH07 jack box 7#
+1Ld8,8,8,6.1839,#Electrode A-CH08 jack box 8#
+1Ld9,9,9,6.1839,#Electrode A-CH09 jack box 9#
+1Ld10,10,10,6.1839,#Electrode A-CH10 jack box 10#
+3Ld1,11,11,6.1839,#Electrode A-CH11 jack box 11#
+3Ld2,12,12,6.1839,#Electrode A-CH12 jack box 12#
+3Ld3,13,13,6.1839,#Electrode A-CH13 jack box 13#
+3Ld4,14,14,6.1839,#Electrode A-CH14 jack box 14#
+3Ld5,15,15,6.1839,#Electrode A-CH15 jack box 15#
+3Ld6,16,16,6.1839,#Electrode A-CH16 jack box 16#
+3Ld7,17,17,6.1839,#Electrode A-CH17 jack box 17#
+3Ld8,18,18,6.1839,#Electrode A-CH18 jack box 18#
+3Ld9,19,19,6.1839,#Electrode A-CH19 jack box 19#
+3Ld10,20,20,6.1839,#Electrode A-CH20 jack box 20#
+5Ld1,21,21,6.3101,#Electrode A-CH21 jack box 21#
+5Ld2,22,22,6.3101,#Electrode A-CH22 jack box 22#
+5Ld3,23,23,6.3101,#Electrode A-CH23 jack box 23#
+5Ld4,24,24,6.3101,#Electrode A-CH24 jack box 24#
+5Ld5,25,25,6.3101,#Electrode A-CH25 jack box 25#
+5Ld6,26,26,6.3101,#Electrode A-CH26 jack box 26#
+5Ld7,27,27,6.3101,#Electrode A-CH27 jack box 27#
+5Ld8,28,28,6.3101,#Electrode A-CH28 jack box 28#
+7Ld3,29,29,6.1839,#Electrode A-CH29 jack box 29#
+7Ld4,30,30,6.1839,#Electrode A-CH30 jack box 30#
+7Ld5,31,31,6.1839,#Electrode A-CH31 jack box 31#
+7Ld6,32,32,6.1839,#Electrode A-CH32 jack box 32#
+7Ld7,33,33,6.1839,#Electrode A-CH33 jack box 33#
+7Ld8,34,34,6.1839,#Electrode A-CH34 jack box 34#
+9Ld1,35,35,6.1839,#Electrode A-CH35 jack box 35#
+9Ld2,36,36,6.1839,#Electrode A-CH36 jack box 36#
+9Ld3,37,37,6.1839,#Electrode A-CH37 jack box 37#
+9Ld4,38,38,6.1839,#Electrode A-CH38 jack box 38#
+9Ld5,39,39,6.1839,#Electrode A-CH39 jack box 39#
+9Ld6,40,40,6.1839,#Electrode A-CH40 jack box 40#
+9Ld7,41,41,6.1839,#Electrode A-CH41 jack box 41#
+9Ld8,42,42,6.1839,#Electrode A-CH42 jack box 42#
+9Ld9,43,43,6.1839,#Electrode A-CH43 jack box 43#
+11Ld1,44,44,6.1839,#Electrode A-CH44 jack box 44#
+11Ld2,45,45,6.1839,#Electrode A-CH45 jack box 45#
+11Ld3,46,46,6.1839,#Electrode A-CH46 jack box 46#
+11Ld4,47,47,6.1839,#Electrode A-CH47 jack box 47#
+11Ld8,48,48,6.1839,#Electrode A-CH48 jack box 48#
+11Ld9,49,49,6.1839,#Electrode A-CH49 jack box 49#
+11Ld10,50,50,6.1839,#Electrode A-CH50 jack box 50#
+13Ld1,51,51,6.1839,#Electrode A-CH51 jack box 51#
+13Ld2,52,52,6.1839,#Electrode A-CH52 jack box 52#
+13Ld3,53,53,6.1839,#Electrode A-CH53 jack box 53#
+13Ld4,54,54,6.1839,#Electrode A-CH54 jack box 54#
+13Ld5,55,55,6.1839,#Electrode A-CH55 jack box 55#
+13Ld6,56,56,6.1839,#Electrode A-CH56 jack box 56#
+13Ld8,57,57,6.1839,#Electrode A-CH57 jack box 57#
+13Ld9,58,58,6.1839,#Electrode A-CH58 jack box 58#
+15Ld1,59,59,6.1839,#Electrode A-CH59 jack box 59#
+15Ld2,60,60,6.1839,#Electrode A-CH60 jack box 60#
+15Ld3,61,61,6.1839,#Electrode A-CH61 jack box 61#
+15Ld4,62,62,6.1839,#Electrode A-CH62 jack box 62#
+15Ld5,63,63,6.1839,#Electrode A-CH63 jack box 63#
+15Ld6,64,64,6.1839,#Electrode B-CH00 jack box 64#
+15Ld7,65,65,6.1839,#Electrode B-CH01 jack box 65#
+15Ld8,66,66,6.1839,#Electrode B-CH02 jack box 66#
+15Ld9,67,67,6.1839,#Electrode B-CH03 jack box 67#
+17Ld1,68,68,6.1839,#Electrode B-CH04 jack box 68#
+17Ld2,69,69,6.1839,#Electrode B-CH05 jack box 69#
+17Ld3,70,70,6.1839,#Electrode B-CH06 jack box 70#
+17Ld4,71,71,6.1839,#Electrode B-CH07 jack box 71#
+17Ld5,72,72,6.1839,#Electrode B-CH08 jack box 72#
+17Ld6,73,73,6.1839,#Electrode B-CH09 jack box 73#
+17Ld7,74,74,6.1839,#Electrode B-CH10 jack box 74#
+17Ld8,75,75,6.1839,#Electrode B-CH11 jack box 75#
+19Ld1,76,76,6.1839,#Electrode B-CH12 jack box 76#
+19Ld2,77,77,6.1839,#Electrode B-CH13 jack box 77#
+19Ld3,78,78,6.1839,#Electrode B-CH14 jack box 78#
+19Ld4,79,79,6.1839,#Electrode B-CH15 jack box 79#
+19Ld5,80,80,6.1839,#Electrode B-CH16 jack box 80#
+19Ld6,81,81,6.1839,#Electrode B-CH17 jack box 81#
+19Ld7,82,82,6.1839,#Electrode B-CH18 jack box 82#
+19Ld8,83,83,6.1839,#Electrode B-CH19 jack box 83#
+21Ld1,84,84,6.1839,#Electrode B-CH20 jack box 84#
+21Ld3,85,85,6.1839,#Electrode B-CH21 jack box 85#
+21Ld5,86,86,6.1839,#Electrode B-CH22 jack box 86#
+21Ld7,87,87,6.1839,#Electrode B-CH23 jack box 87#
+21Ld8,88,88,6.1839,#Electrode B-CH24 jack box 88#
+23Ld1,89,89,6.1839,#Electrode B-CH25 jack box 89#
+23Ld2,90,90,6.1839,#Electrode B-CH26 jack box 90#
+23Ld3,91,91,6.1839,#Electrode B-CH27 jack box 91#
+23Ld4,92,92,6.1839,#Electrode B-CH28 jack box 92#
+23Ld5,93,93,6.1839,#Electrode B-CH29 jack box 93#
+23Ld6,94,94,6.1839,#Electrode B-CH30 jack box 94#
+23Ld7,95,95,6.1839,#Electrode B-CH31 jack box 95#
+25Ld1,96,96,6.3101,#Electrode B-CH32 jack box 96#
+25Ld2,98,98,6.3101,#Electrode B-CH34 jack box 98#
+25Ld3,99,99,6.3101,#Electrode B-CH35 jack box 99#
+25Ld4,100,100,6.3101,#Electrode B-CH36 jack box 100#
+25Ld5,101,101,6.3101,#Electrode B-CH37 jack box 101#
+25Ld6,102,102,6.3101,#Electrode B-CH38 jack box 102#
+25Ld7,103,103,6.3101,#Electrode B-CH39 jack box 103#
+25Ld8,104,104,6.3101,#Electrode B-CH40 jack box 104#
+27Ld1,105,105,6.1839,#Electrode B-CH41 jack box 105#
+27Ld2,106,106,6.1839,#Electrode B-CH42 jack box 106#
+27Ld3,107,107,6.1839,#Electrode B-CH43 jack box 107#
+27Ld4,108,108,6.1839,#Electrode B-CH44 jack box 108#
+27Ld5,109,109,6.1839,#Electrode B-CH45 jack box 109#
+27Ld6,110,110,6.1839,#Electrode B-CH46 jack box 110#
+27Ld7,111,111,6.1839,#Electrode B-CH47 jack box 111#
+27Ld8,112,112,6.1839,#Electrode B-CH48 jack box 112#
+29Ld3,113,113,6.1839,#Electrode B-CH49 jack box 113#
+29Ld4,114,114,6.1839,#Electrode B-CH50 jack box 114#
+29Ld5,115,115,6.1839,#Electrode B-CH51 jack box 115#
+29Ld6,116,116,6.1839,#Electrode B-CH52 jack box 116#
+2Rd1,117,117,6.1839,#Electrode B-CH53 jack box 117#
+2Rd3,118,118,6.1839,#Electrode B-CH54 jack box 118#
+2Rd5,119,119,6.1839,#Electrode B-CH55 jack box 119#
+2Rd7,120,120,6.1839,#Electrode B-CH56 jack box 120#
+4Rd1,121,121,6.1839,#Electrode B-CH57 jack box 121#
+4Rd3,122,122,6.1839,#Electrode B-CH58 jack box 122#
+4Rd5,123,123,6.1839,#Electrode B-CH59 jack box 123#
+4Rd7,124,124,6.1839,#Electrode B-CH60 jack box 124#
+8Rd1,125,125,6.1839,#Electrode B-CH61 jack box 125#
+8Rd3,126,126,6.1839,#Electrode B-CH62 jack box 126#
+8Rd5,127,127,6.1839,#Electrode B-CH63 jack box 127#
+SenseChannelSubclasses:
+SenseChannels:
+1Ld1,1Ld11Ld2,1,2,x,#1Ld1-1Ld2#
+1Ld2,1Ld21Ld3,2,3,x,#1Ld2-1Ld3#
+1Ld3,1Ld31Ld4,3,4,x,#1Ld3-1Ld4#
+1Ld4,1Ld41Ld5,4,5,x,#1Ld4-1Ld5#
+1Ld5,1Ld51Ld6,5,6,x,#1Ld5-1Ld6#
+1Ld6,1Ld61Ld7,6,7,x,#1Ld6-1Ld7#
+1Ld7,1Ld71Ld8,7,8,x,#1Ld7-1Ld8#
+1Ld8,1Ld81Ld9,8,9,x,#1Ld8-1Ld9#
+1Ld9,1Ld91Ld10,9,10,x,#1Ld9-1Ld10#
+1Ld10,1Ld101Ld1,10,1,x,#1Ld10-1Ld1#
+3Ld1,3Ld13Ld2,11,12,x,#3Ld1-3Ld2#
+3Ld2,3Ld23Ld3,12,13,x,#3Ld2-3Ld3#
+3Ld3,3Ld33Ld4,13,14,x,#3Ld3-3Ld4#
+3Ld4,3Ld43Ld5,14,15,x,#3Ld4-3Ld5#
+3Ld5,3Ld53Ld6,15,16,x,#3Ld5-3Ld6#
+3Ld6,3Ld63Ld7,16,17,x,#3Ld6-3Ld7#
+3Ld7,3Ld73Ld8,17,18,x,#3Ld7-3Ld8#
+3Ld8,3Ld83Ld9,18,19,x,#3Ld8-3Ld9#
+3Ld9,3Ld93Ld10,19,20,x,#3Ld9-3Ld10#
+3Ld10,3Ld103Ld1,20,11,x,#3Ld10-3Ld1#
+5Ld1,5Ld15Ld2,21,22,x,#5Ld1-5Ld2#
+5Ld2,5Ld25Ld3,22,23,x,#5Ld2-5Ld3#
+5Ld3,5Ld35Ld4,23,24,x,#5Ld3-5Ld4#
+5Ld4,5Ld45Ld5,24,25,x,#5Ld4-5Ld5#
+5Ld5,5Ld55Ld6,25,26,x,#5Ld5-5Ld6#
+5Ld6,5Ld65Ld7,26,27,x,#5Ld6-5Ld7#
+5Ld7,5Ld75Ld8,27,28,x,#5Ld7-5Ld8#
+5Ld8,5Ld85Ld1,28,21,x,#5Ld8-5Ld1#
+7Ld3,7Ld37Ld4,29,30,x,#7Ld3-7Ld4#
+7Ld4,7Ld47Ld5,30,31,x,#7Ld4-7Ld5#
+7Ld5,7Ld57Ld6,31,32,x,#7Ld5-7Ld6#
+7Ld6,7Ld67Ld3,32,29,x,#7Ld6-7Ld3#
+7Ld7,7Ld77Ld8,33,34,x,#7Ld7-7Ld8#
+7Ld8,7Ld87Ld7,34,33,x,#7Ld8-7Ld7#
+9Ld1,9Ld19Ld2,35,36,x,#9Ld1-9Ld2#
+9Ld2,9Ld29Ld3,36,37,x,#9Ld2-9Ld3#
+9Ld3,9Ld39Ld4,37,38,x,#9Ld3-9Ld4#
+9Ld4,9Ld49Ld5,38,39,x,#9Ld4-9Ld5#
+9Ld5,9Ld59Ld6,39,40,x,#9Ld5-9Ld6#
+9Ld6,9Ld69Ld7,40,41,x,#9Ld6-9Ld7#
+9Ld7,9Ld79Ld8,41,42,x,#9Ld7-9Ld8#
+9Ld8,9Ld89Ld9,42,43,x,#9Ld8-9Ld9#
+9Ld9,9Ld99Ld1,43,35,x,#9Ld9-9Ld1#
+11Ld1,11Ld111Ld2,44,45,x,#11Ld1-11Ld2#
+11Ld2,11Ld211Ld3,45,46,x,#11Ld2-11Ld3#
+11Ld3,11Ld311Ld4,46,47,x,#11Ld3-11Ld4#
+11Ld4,11Ld411Ld8,47,48,x,#11Ld4-11Ld8#
+11Ld8,11Ld811Ld9,48,49,x,#11Ld8-11Ld9#
+11Ld9,11Ld911Ld10,49,50,x,#11Ld9-11Ld10#
+11Ld10,11Ld1011Ld1,50,44,x,#11Ld10-11Ld1#
+13Ld1,13Ld113Ld2,51,52,x,#13Ld1-13Ld2#
+13Ld2,13Ld213Ld3,52,53,x,#13Ld2-13Ld3#
+13Ld3,13Ld313Ld4,53,54,x,#13Ld3-13Ld4#
+13Ld4,13Ld413Ld5,54,55,x,#13Ld4-13Ld5#
+13Ld5,13Ld513Ld6,55,56,x,#13Ld5-13Ld6#
+13Ld6,13Ld613Ld8,56,57,x,#13Ld6-13Ld8#
+13Ld8,13Ld813Ld9,57,58,x,#13Ld8-13Ld9#
+13Ld9,13Ld913Ld1,58,51,x,#13Ld9-13Ld1#
+15Ld1,15Ld115Ld2,59,60,x,#15Ld1-15Ld2#
+15Ld2,15Ld215Ld3,60,61,x,#15Ld2-15Ld3#
+15Ld3,15Ld315Ld4,61,62,x,#15Ld3-15Ld4#
+15Ld4,15Ld415Ld5,62,63,x,#15Ld4-15Ld5#
+15Ld5,15Ld515Ld6,63,64,x,#15Ld5-15Ld6#
+15Ld6,15Ld615Ld1,64,59,x,#15Ld6-15Ld1#
+15Ld7,15Ld715Ld8,65,66,x,#15Ld7-15Ld8#
+15Ld8,15Ld815Ld9,66,67,x,#15Ld8-15Ld9#
+15Ld9,15Ld915Ld7,67,65,x,#15Ld9-15Ld7#
+17Ld1,17Ld117Ld2,68,69,x,#17Ld1-17Ld2#
+17Ld2,17Ld217Ld3,69,70,x,#17Ld2-17Ld3#
+17Ld3,17Ld317Ld4,70,71,x,#17Ld3-17Ld4#
+17Ld4,17Ld417Ld5,71,72,x,#17Ld4-17Ld5#
+17Ld5,17Ld517Ld6,72,73,x,#17Ld5-17Ld6#
+17Ld6,17Ld617Ld7,73,74,x,#17Ld6-17Ld7#
+17Ld7,17Ld717Ld8,74,75,x,#17Ld7-17Ld8#
+17Ld8,17Ld817Ld1,75,68,x,#17Ld8-17Ld1#
+19Ld1,19Ld119Ld2,76,77,x,#19Ld1-19Ld2#
+19Ld2,19Ld219Ld3,77,78,x,#19Ld2-19Ld3#
+19Ld3,19Ld319Ld4,78,79,x,#19Ld3-19Ld4#
+19Ld4,19Ld419Ld5,79,80,x,#19Ld4-19Ld5#
+19Ld5,19Ld519Ld6,80,81,x,#19Ld5-19Ld6#
+19Ld6,19Ld619Ld7,81,82,x,#19Ld6-19Ld7#
+19Ld7,19Ld719Ld8,82,83,x,#19Ld7-19Ld8#
+19Ld8,19Ld819Ld1,83,76,x,#19Ld8-19Ld1#
+21Ld1,21Ld121Ld3,84,85,x,#21Ld1-21Ld3#
+21Ld3,21Ld321Ld5,85,86,x,#21Ld3-21Ld5#
+21Ld5,21Ld521Ld7,86,87,x,#21Ld5-21Ld7#
+21Ld7,21Ld721Ld8,87,88,x,#21Ld7-21Ld8#
+21Ld8,21Ld821Ld1,88,84,x,#21Ld8-21Ld1#
+23Ld1,23Ld123Ld2,89,90,x,#23Ld1-23Ld2#
+23Ld2,23Ld223Ld3,90,91,x,#23Ld2-23Ld3#
+23Ld3,23Ld323Ld4,91,92,x,#23Ld3-23Ld4#
+23Ld4,23Ld423Ld5,92,93,x,#23Ld4-23Ld5#
+23Ld5,23Ld523Ld6,93,94,x,#23Ld5-23Ld6#
+23Ld6,23Ld623Ld7,94,95,x,#23Ld6-23Ld7#
+23Ld7,23Ld723Ld1,95,89,x,#23Ld7-23Ld1#
+25Ld2,25Ld225Ld3,98,99,x,#25Ld2-25Ld3#
+25Ld3,25Ld325Ld4,99,100,x,#25Ld3-25Ld4#
+25Ld4,25Ld425Ld5,100,101,x,#25Ld4-25Ld5#
+25Ld5,25Ld525Ld6,101,102,x,#25Ld5-25Ld6#
+25Ld6,25Ld625Ld7,102,103,x,#25Ld6-25Ld7#
+25Ld7,25Ld725Ld8,103,104,x,#25Ld7-25Ld8#
+25Ld8,25Ld825Ld2,104,98,x,#25Ld8-25Ld2#
+27Ld1,27Ld127Ld2,105,106,x,#27Ld1-27Ld2#
+27Ld2,27Ld227Ld3,106,107,x,#27Ld2-27Ld3#
+27Ld3,27Ld327Ld4,107,108,x,#27Ld3-27Ld4#
+27Ld4,27Ld427Ld5,108,109,x,#27Ld4-27Ld5#
+27Ld5,27Ld527Ld6,109,110,x,#27Ld5-27Ld6#
+27Ld6,27Ld627Ld7,110,111,x,#27Ld6-27Ld7#
+27Ld7,27Ld727Ld8,111,112,x,#27Ld7-27Ld8#
+27Ld8,27Ld827Ld1,112,105,x,#27Ld8-27Ld1#
+29Ld3,29Ld329Ld4,113,114,x,#29Ld3-29Ld4#
+29Ld4,29Ld429Ld5,114,115,x,#29Ld4-29Ld5#
+29Ld5,29Ld529Ld6,115,116,x,#29Ld5-29Ld6#
+29Ld6,29Ld629Ld3,116,113,x,#29Ld6-29Ld3#
+2Rd1,2Rd12Rd3,117,118,x,#2Rd1-2Rd3#
+2Rd3,2Rd32Rd5,118,119,x,#2Rd3-2Rd5#
+2Rd5,2Rd52Rd7,119,120,x,#2Rd5-2Rd7#
+2Rd7,2Rd72Rd1,120,117,x,#2Rd7-2Rd1#
+4Rd1,4Rd14Rd3,121,122,x,#4Rd1-4Rd3#
+4Rd3,4Rd34Rd5,122,123,x,#4Rd3-4Rd5#
+4Rd5,4Rd54Rd7,123,124,x,#4Rd5-4Rd7#
+4Rd7,4Rd74Rd1,124,121,x,#4Rd7-4Rd1#
+8Rd1,8Rd18Rd3,125,126,x,#8Rd1-8Rd3#
+8Rd3,8Rd38Rd5,126,127,x,#8Rd3-8Rd5#
+8Rd5,8Rd58Rd1,127,125,x,#8Rd5-8Rd1#
+StimulationChannelSubclasses:
+StimulationChannels:
+StimChannel:,1Ld9_1Ld10,x,# #
+Anodes:,9,#
+Cathodes:,10,#
+StimChannel:,25Ld7_25Ld8,x,# #
+Anodes:,103,#
+Cathodes:,104,#
+StimChannel:,5Ld7_5Ld8,x,# #
+Anodes:,27,#
+Cathodes:,28,#
+StimChannel:,3Ld9_3Ld10,x,# #
+Anodes:,19,#
+Cathodes:,20,#
+REF:,0,Common
+EOF

--- a/system_3_utils/ram_tasks/CMLParserClosedLoop3.py
+++ b/system_3_utils/ram_tasks/CMLParserClosedLoop3.py
@@ -4,9 +4,12 @@ from os.path import *
 
 # Valid experiments that we can generate Ramulator configuration files for
 _EXP_CHOICES = [
-    'FR5', 'catFR5',
-    'PS4_FR5', 'PS4_catFR5',
-    'FR6', 'catFR6',
+    'FR5',
+    'catFR5',
+    'PS4_FR5', 
+    'PS4_CatFR5',
+    'FR6',
+    'catFR6',
 ]
 
 

--- a/tests/fr5_biomarker/system3/ExperimentConfigGeneratorClosedLoop5.py
+++ b/tests/fr5_biomarker/system3/ExperimentConfigGeneratorClosedLoop5.py
@@ -118,7 +118,7 @@ class ExperimentConfigGeneratorClosedLoop5(RamTask):
         self.create_dir_in_workspace(abspath(join(project_dir,'config_files')))
         config_files_dir = self.get_path_to_resource_in_workspace(project_dir_corename+'/config_files')
 
-        if 'FR5' not in experiment:
+        if (experiment.lower() != "fr5") and (experiment.lower() != "catfr5"):
             # All experiments after FR5 share a similar config format to PS4,
             # namely the stim channels are defined in a dict-like form.
             prefix = 'PS4_FR5'


### PR DESCRIPTION
Config generator was not correctly determining the template to use based on the given experiment. Also updated the allowed experiments because PS4_catFR5 is not recognized by RAMULATOR, but PS4_CatFR5 was not originally allowed by the argument parser