### PR TITLE
Arbitrary Number of Classifiers

### DIFF
--- a/ramutils/events.py
+++ b/ramutils/events.py
@@ -664,6 +664,16 @@ def select_word_events(events, encoding_only=True):
         Flag for whether retrieval events should be included
 
     """
+    mask = get_word_event_mask(events, encoding_only=encoding_only)
+    filtered_events = events[mask]
+    events = filtered_events.view(np.recarray)
+
+    return events
+
+
+def get_word_event_mask(events, encoding_only):
+    """ Get a mask identify word events. If encoding_only, then retrieval
+    events will not be counted """
     encoding_events_mask = get_encoding_mask(events)
     retrieval_event_mask = get_all_retrieval_events_mask(events)
 
@@ -672,10 +682,7 @@ def select_word_events(events, encoding_only=True):
     else:
         mask = (encoding_events_mask | retrieval_event_mask)
 
-    filtered_events = events[mask]
-    events = filtered_events.view(np.recarray)
-
-    return events
+    return mask
 
 
 def extract_event_metadata(events):
@@ -743,7 +750,7 @@ def get_session_mask(events, session):
 
 
 def select_stim_table_events(events):
-    """ Return the events needed to build stim session summary """
+    """ Return the events needed to build stim session summaries """
     events = remove_practice_lists(events)
     mask = get_stim_table_event_mask(events)
     stim_table_events = events[mask]
@@ -850,6 +857,11 @@ def extract_stim_information(all_events, task_events):
                             stim_params = lst_events[loc].stim_params
                             if type(stim_params) != np.ndarray:
                                 stim_params = np.array([stim_params])
+
+                            # TODO: Add location field to stim params by
+                            # looking up the contacts in the pairs metadata
+                            # table, which would need to be passed to this
+                            # function
 
                             stim_param_data['item_name'].append(lst_events[loc].item_name)
                             stim_param_data['session'].append(lst_events[loc].session)

--- a/ramutils/pipelines/report.py
+++ b/ramutils/pipelines/report.py
@@ -95,6 +95,7 @@ def make_report(subject, experiment, paths, joint_report=False,
                                                         reduced_powers,
                                                         final_task_events,
                                                         kwargs['n_perm'],
+                                                        tag='Joint Classifier',
                                                         **kwargs)
 
         # FIXME: We don't technically need this right now, but in the future,
@@ -184,7 +185,7 @@ def make_report(subject, experiment, paths, joint_report=False,
     math_summaries = summarize_math(all_events, joint=joint_report)
 
     if not stim_report:
-        results = classifier_summaries
+        results = [classifier_summaries]
     else:
         results = post_hoc_results['session_summaries']
 

--- a/ramutils/reports/generate.py
+++ b/ramutils/reports/generate.py
@@ -46,11 +46,11 @@ class ReportGenerator(object):
 
     """
     def __init__(self, session_summaries, math_summaries,
-                 sme_table, classifier_summary, dest='.'):
+                 sme_table, classifier_summaries, dest='.'):
         self.session_summaries = session_summaries
         self.math_summaries = math_summaries
         self.sme_table = sme_table
-        self.classifier_summary = classifier_summary
+        self.classifiers = classifier_summaries
 
         if len(session_summaries) != len(math_summaries):
             raise ValueError("Summaries contain different numbers of sessions")
@@ -107,11 +107,7 @@ class ReportGenerator(object):
         return sme_table
 
     def _make_classifier_data(self):
-        """Create JSON object for classifier data.
-
-        FIXME: real data
-
-        """
+        """Create JSON object for classifier data """
         return {
             'auc': self.classifier_summary.auc,
             'p_value': self.classifier_summary.pvalue,
@@ -157,7 +153,7 @@ class ReportGenerator(object):
             summaries=self.session_summaries,
             math_summaries=self.math_summaries,
             combined_summary=self._make_combined_summary(),
-            classifier=self._make_classifier_data(),
+            classifiers=self.classifiers,
             **kwargs
         )
 
@@ -182,14 +178,16 @@ class ReportGenerator(object):
                     }
                 }),
                 'roc': json.dumps({
-                    'fpr': self.classifier_summary.false_positive_rate,
-                    'tpr': self.classifier_summary.true_positive_rate
+                    'fpr': [classifier.false_positive_rate for classifier in self.classifiers],
+                    'tpr': [classifier.true_positive_rate for classifier in self.classifiers],
                 }),
                 'tercile': json.dumps({
-                    'low': self.classifier_summary.low_tercile_diff_from_mean,
-                    'mid': self.classifier_summary.mid_tercile_diff_from_mean,
-                    'high': self.classifier_summary.high_tercile_diff_from_mean
-                })
+                    'low': [classifier.low_tercile_diff_from_mean for classifier in self.classifiers],
+                    'mid': [classifier.mid_tercile_diff_from_mean for classifier in self.classifiers],
+                    'high': [classifier.high_tercile_diff_from_mean for classifier in self.classifiers]
+                }),
+                'tags': json.dumps([classifier.metadata['tag'] for classifier
+                                    in self.classifiers])
             },
             sme_table=self._make_sme_table(),
         )

--- a/ramutils/reports/static/plots.js
+++ b/ramutils/reports/static/plots.js
@@ -148,15 +148,8 @@ var ramutils = (function (mod, Plotly) {
      * @param {Number} middle
      * @param {Number} high
      */
-    plotClassifierPerformance: function (fpr, tpr, low, middle, high) {
-      const data = [
-        {
-          x: fpr,
-          y: tpr,
-          type: 'scatter',
-          mode: 'lines',
-          name: 'ROC'
-        },
+    plotClassifierPerformance: function (fpr, tpr, low, middle, high, tags) {
+      let data = [
         {
           x: [0, 1],
           y: [0, 1],
@@ -164,19 +157,33 @@ var ramutils = (function (mod, Plotly) {
           line: {
             color: 'black',
             dash: 'dot'
-          }
-        },
-        {
-          x: ['low', 'middle', 'high'],
-          y: [low, middle, high],
-          xaxis: 'x2',
-          yaxis: 'y2',
-          type: 'bar',
-          name: 'Tercile'
+          },
+          showlegend: false
         },
       ];
 
-      const layout = {
+      for (i = 0; i < fpr.length; i++) {
+        const tag = tags[i];
+        const roc_curve = {
+          x: fpr[i],
+          y: tpr[i],
+          type: 'scatter',
+          mode: 'lines',
+          name: `${tag} ROC Curve`
+        };
+        const tercile = {
+          x: ['low', 'middle', 'high'],
+          y: [low[i], middle[i], high[i]],
+          xaxis: 'x2',
+          yaxis: 'y2',
+          type: 'bar',
+          name: `${tag} Tercile`
+        };
+        data.push(roc_curve);
+        data.push(tercile);
+      }
+
+     const layout = {
         xaxis: {
           title: 'False positive rate',
           domain: [0, 0.45],
@@ -195,7 +202,7 @@ var ramutils = (function (mod, Plotly) {
           anchor: 'x2'
         },
 
-        showlegend: false,
+        showlegend: true,
 
         // FIXME: responsive and square aspect ratio?
         width: 1000,

--- a/ramutils/reports/templates/classifier.html
+++ b/ramutils/reports/templates/classifier.html
@@ -4,23 +4,38 @@
     <div id="classifier-performance-plot-placeholder"></div>
     <figcaption>
       <b>(Left)</b> ROC curve for subject {{ subject }}. <b>(Right)</b> Subject
-      recall performance represented as percentage devation from the (subject)
+      recall performance represented as percentage deviation from the (subject)
       mean, separated by tercile of the classifier encoding efficiency estimate
       for each encoded word.
     </figcaption>
   </figure>
 
-  <ul>
-    <li>Area under curve: {{ '{:.2f}%'.format(classifier['auc']) }}</li>
-    <li>Permutation test p-value: {{ classifier['p_value']|pvalue }}</li>
-    <li>Median of classifier output: {{ classifier['output_median'] }}</li>
-  </ul>
-
+  <table class="table">
+    <thead>
+    <tr>
+      <td>Classifier</td>
+      <td>AUC</td>
+      <td>Permutation P-Value</td>
+      <td>Median Classifier Output</td>
+    </tr>
+    </thead>
+    <tbody>
+    {% for classifier in classifiers %}
+      <tr>
+        <td>{{ classifier.metadata['tag'] }}</td>
+        <td>{{ classifier.auc }}</td>
+        <td>{{ classifier.pvalue }}</td>
+        <td>{{ classifier.median_classifier_output }}</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
   <script>
     window.addEventListener('load', () => {
       let rocData = JSON.parse('{{ plot_data["roc"] }}');
       let tercData = JSON.parse('{{ plot_data["tercile"] }}');
-      ramutils.plots.plotClassifierPerformance(rocData.fpr, rocData.tpr, tercData.low, tercData.mid, tercData.high);
+      let tags = JSON.parse('{{ plot_data["tags"] }}');
+      ramutils.plots.plotClassifierPerformance(rocData.fpr, rocData.tpr, tercData.low, tercData.mid, tercData.high, tags);
     });
   </script>
 </div>

--- a/ramutils/tasks/classifier.py
+++ b/ramutils/tasks/classifier.py
@@ -91,7 +91,7 @@ def serialize_classifier(classifier, pairs, features, events, sample_weights,
 
 
 @task()
-def perform_cross_validation(classifier, pow_mat, events, n_permutations,
+def perform_cross_validation(classifier, pow_mat, events, n_permutations, tag,
                              **kwargs):
     """Perform LOSO or LOLO cross validation on a classifier.
 
@@ -101,6 +101,8 @@ def perform_cross_validation(classifier, pow_mat, events, n_permutations,
     pow_mat : np.ndarray
     events : np.recarray
     n_permutations: int
+    tag: str
+        Tag to assign the resulting classifier summary
     kwargs: dict
         Extra keyword arguments that are passed to get_sample_weights. See
         that function for more details
@@ -130,7 +132,7 @@ def perform_cross_validation(classifier, pow_mat, events, n_permutations,
                                               recalls, **kwargs)
         classifier_summary.populate(subject, experiment,
                                     sessions, encoding_recalls, probs,
-                                    permuted_auc_values)
+                                    permuted_auc_values, tag=tag)
 
     else:
         logger.info("Performing LOLO cross validation")
@@ -144,7 +146,7 @@ def perform_cross_validation(classifier, pow_mat, events, n_permutations,
 
         classifier_summary.populate(subject, experiment,
                                     sessions, encoding_recalls, probs,
-                                    permuted_auc_values)
+                                    permuted_auc_values, tag=tag)
 
     logger.info("Permutation test p-value = %f", classifier_summary.pvalue)
     recall_prob = classifier.predict_proba(pow_mat)[:, 1]

--- a/ramutils/tasks/events.py
+++ b/ramutils/tasks/events.py
@@ -2,13 +2,27 @@
 
 from ramutils.events import load_events, clean_events, select_word_events, \
     concatenate_events_across_experiments
+from ramutils.events import get_word_event_mask as get_word_event_mask_core
 from ramutils.tasks import task
 from ramutils.utils import extract_experiment_series
 
 __all__ = [
+    'get_word_event_mask',
+    'subset_events',
     'build_test_data',
     'build_training_data'
 ]
+
+
+@task(cache=False)
+def get_word_event_mask(events, encoding_only):
+    return get_word_event_mask_core(events, encoding_only)
+
+
+@task(cache=False)
+def subset_events(events, mask):
+    events_subset = events[mask]
+    return events_subset
 
 
 @task()

--- a/ramutils/tasks/powers.py
+++ b/ramutils/tasks/powers.py
@@ -13,6 +13,7 @@ logger = get_logger()
 __all__ = [
     'compute_normalized_powers',
     'reduce_powers',
+    'subset_powers',
     'calculate_delta_hfa_table'
 ]
 
@@ -21,6 +22,12 @@ __all__ = [
 def reduce_powers(powers, mask, n_frequencies):
     reduced_powers = reduce_powers_core(powers, mask, n_frequencies)
     return reduced_powers
+
+
+@task(cache=False)
+def subset_powers(powers, mask):
+    condensed_powers = powers[mask, :]
+    return condensed_powers
 
 
 @task(nout=2)

--- a/ramutils/test/tasks/test_classifier.py
+++ b/ramutils/test/tasks/test_classifier.py
@@ -36,7 +36,10 @@ class TestCrossValidation:
         events = np.load(
             datafile('/events/{}_task_events.npy'.format(subject))).view(
             np.recarray)
-        classifier_summary = perform_cross_validation(classifier, powers, events, 10 ,**params).compute()
+        classifier_summary = perform_cross_validation(classifier, powers,
+                                                      events, 10 ,
+                                                      tag='test',
+                                                      **params).compute()
         assert np.isclose(classifier_summary.auc, expected_output[subject],
                           rtol=1e-3)
         return
@@ -69,7 +72,11 @@ class TestCrossValidation:
         sess_mask = (events.session == test_session)
         events = events[events.session == test_session]
         powers = powers[sess_mask, :]
-        classifier_summary = perform_cross_validation(classifier, powers, events, 10, **params).compute()
+        classifier_summary = perform_cross_validation(classifier,
+                                                      powers,
+                                                      events, 10,
+                                                      tag='test',
+                                                      **params).compute()
         assert np.isclose(classifier_summary.auc, expected_output[subject],
                           rtol=1e-3)
 


### PR DESCRIPTION
Implements the ability to plot arbitrary numbers of classifier summaries where classifiers are differentiated based on their 'tag'. Classifier performance metrics are now displayed as a table instead of bulleted list. Computation of both a joint and encoding-only classifier is now part of the standard report pipeline.