### PR TITLE
Fix bug where non-task was used in a pipeline

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changes
 =======
 
+Version 2.1.1
+-------------
+
+Unreleased
+
+* Fixed a bug with Ramulator config generation where one step in the pipeline
+  was not a task (#100)
+
+
 Version 2.1.0
 -------------
 

--- a/ramutils/cli/expconf.py
+++ b/ramutils/cli/expconf.py
@@ -177,3 +177,12 @@ def create_expconf(input_args=None):
 
 if __name__ == "__main__":
     create_expconf()
+
+    # create_expconf([
+    #     '-s', 'R1385E',
+    #     '-x', 'FR1',
+    #     '--root', '~/mnt/rhino',
+    #     '-d', 'scratch/depalati',
+    #     '--area-file', 'data10/RAM/subjects/R1385E/docs/area.txt',
+    #     '--force-rerun'
+    # ])

--- a/ramutils/pipelines/ramulator_config.py
+++ b/ramutils/pipelines/ramulator_config.py
@@ -54,7 +54,9 @@ def make_ramulator_config(subject, experiment, paths, stim_params,
     # Note: All of these pairs variables are of type OrderedDict, which is
     # crucial for preserving the initial order of the electrodes in the
     # config file
-    ec_pairs = generate_pairs_from_electrode_config(subject, paths)
+    #
+    # generate_pairs_from_electrode_config isn't defined as a task...
+    ec_pairs = make_task(generate_pairs_from_electrode_config, subject, paths)
     excluded_pairs = reduce_pairs(ec_pairs, stim_params, True)
     used_pair_mask = get_used_pair_mask(ec_pairs, excluded_pairs)
     final_pairs = generate_pairs_for_classifier(ec_pairs, excluded_pairs)

--- a/ramutils/tasks/montage.py
+++ b/ramutils/tasks/montage.py
@@ -6,9 +6,13 @@ from ramutils.montage import get_used_pair_mask as get_used_pair_mask_core
 from ramutils.montage import build_montage_metadata_table
 from ramutils.montage import get_pairs as get_pairs_core
 
-__all__ = ['generate_pairs_for_classifier', 'reduce_pairs',
-           'get_used_pair_mask', 'generate_montage_metadata_table',
-           'get_pairs']
+__all__ = [
+    'generate_pairs_for_classifier',
+    'reduce_pairs',
+    'get_used_pair_mask',
+    'generate_montage_metadata_table',
+    'get_pairs',
+]
 
 
 @task()
@@ -36,8 +40,3 @@ def generate_montage_metadata_table(subject, all_pairs, root):
 def get_pairs(subject, experiment, paths, localization=0, montage=0):
     return get_pairs_core(subject, experiment, paths, localization=localization,
                           montage=montage)
-
-
-
-
-


### PR DESCRIPTION
Previously this yielded the following traceback:

```pytb
File "/home1/RAM_clinical/miniconda3/envs/ramutils/bin/ramulator-conf", line 11, in <module>
    load_entry_point('ramutils==2.1.0', 'console_scripts', 'ramulator-conf')()
  File "/home1/RAM_clinical/miniconda3/envs/ramutils/lib/python2.7/site-packages/ramutils-2.1.0-py2.7.egg/ramutils/cli/expconf.py", line 171, in create_expconf
    default_surface_area=default_surface_area)
  File "/home1/RAM_clinical/miniconda3/envs/ramutils/lib/python2.7/site-packages/ramutils-2.1.0-py2.7.egg/ramutils/pipelines/ramulator_config.py", line 57, in make_ramulator_config
    ec_pairs = generate_pairs_from_electrode_config(subject, paths)
  File "/home1/RAM_clinical/miniconda3/envs/ramutils/lib/python2.7/site-packages/ramutils-2.1.0-py2.7.egg/ramutils/montage.py", line 444, in generate_pairs_from_electrode_config
    prefix, _ = os.path.splitext(paths.electrode_config_file)
  File "/home1/RAM_clinical/miniconda3/envs/ramutils/lib/python2.7/posixpath.py", line 98, in splitext
    return genericpath._splitext(p, sep, altsep, extsep)
  File "/home1/RAM_clinical/miniconda3/envs/ramutils/lib/python2.7/genericpath.py", line 105, in _splitext
    if dotIndex > sepIndex:
  File "/home1/RAM_clinical/miniconda3/envs/ramutils/lib/python2.7/site-packages/dask/delayed.py", line 415, in __bool__
    raise TypeError("Truth of Delayed objects is not supported")
TypeError: Truth of Delayed objects is not supported
```
with the following input:

```
ramulator-conf -s R1385E -x FR1 --area-file data10/RAM/subjects/R1385E/docs/area.txt --force-rerun
```