### PR TITLE
Include practice lists in calculating number of PLI and ELI

### DIFF
--- a/demos/ramulator_config.py
+++ b/demos/ramulator_config.py
@@ -5,7 +5,8 @@ import os.path
 from pkg_resources import resource_filename
 
 from ramutils.parameters import FilePaths, FRParameters
-from ramutils.pipelines.ramulator_config import make_ramulator_config, make_stim_params
+from ramutils.pipelines.ramulator_config import make_ramulator_config
+from ramutils.montage import make_stim_params
 
 from ramutils.tasks import memory
 

--- a/ramutils/reports/summary.py
+++ b/ramutils/reports/summary.py
@@ -477,8 +477,7 @@ class FRSessionSummary(SessionSummary):
 
     @property
     def intrusion_events(self):
-        intr_events = self.raw_events[(self.raw_events.list > -1) &
-                                      (self.raw_events.type == 'REC_WORD') &
+        intr_events = self.raw_events[(self.raw_events.type == 'REC_WORD') &
                                       (self.raw_events.intrusion != -999) &
                                       (self.raw_events.intrusion != 0)]
         return intr_events

--- a/ramutils/reports/summary.py
+++ b/ramutils/reports/summary.py
@@ -477,7 +477,8 @@ class FRSessionSummary(SessionSummary):
 
     @property
     def intrusion_events(self):
-        intr_events = self.raw_events[(self.raw_events.type == 'REC_WORD') &
+        intr_events = self.raw_events[(self.raw_events.list > -1) &
+                                      (self.raw_events.type == 'REC_WORD') &
                                       (self.raw_events.intrusion != -999) &
                                       (self.raw_events.intrusion != 0)]
         return intr_events

--- a/ramutils/test/test_events.py
+++ b/ramutils/test/test_events.py
@@ -228,8 +228,9 @@ class TestEvents:
         return
 
     def test_append_field(self):
-        appended_data = add_field(self.test_data, 'item_name', 'X')
+        appended_data = add_field(self.test_data, 'item_name', 'X', '<U256')
         assert 'item_name' in appended_data.dtype.names
+        assert appended_data['item_name'].dtype.str == '<U256'
         return
 
     # Four possible partitions. Be sure to check all


### PR DESCRIPTION
Very simple fix to include the practice list when calculating the number of PLI and ELI. Other changes still need to be made to the data processing/annotation pipeline for this to be fully working, but this should be the only change that needs to be made to ramutils/reporting