### PR TITLE
Arbitrary testing loc

### DIFF
--- a/ramutils/pipelines/ramulator_config.py
+++ b/ramutils/pipelines/ramulator_config.py
@@ -55,7 +55,7 @@ def make_ramulator_config(subject, experiment, paths, stim_params,
     # crucial for preserving the initial order of the electrodes in the
     # config file
     ec_pairs = make_task(generate_pairs_from_electrode_config, subject,
-                         paths, localization=localization, montage=montage)
+                         experiment, paths)
     excluded_pairs = reduce_pairs(ec_pairs, stim_params, True)
     used_pair_mask = get_used_pair_mask(ec_pairs, excluded_pairs)
     final_pairs = generate_pairs_for_classifier(ec_pairs, excluded_pairs)

--- a/ramutils/pipelines/report.py
+++ b/ramutils/pipelines/report.py
@@ -60,7 +60,9 @@ def make_report(subject, experiment, paths, joint_report=False,
     excluded_pairs = reduce_pairs(ec_pairs, stim_params, True)
     final_pairs = generate_pairs_for_classifier(ec_pairs, excluded_pairs)
     used_pair_mask = get_used_pair_mask(ec_pairs, excluded_pairs)
-    pairs_metadata_table = generate_montage_metadata_table(subject, ec_pairs,
+    pairs_metadata_table = generate_montage_metadata_table(subject,
+                                                           experiment,
+                                                           ec_pairs,
                                                            root=paths.root)
 
     if 'PS' not in experiment:

--- a/ramutils/tasks/montage.py
+++ b/ramutils/tasks/montage.py
@@ -32,11 +32,11 @@ def get_used_pair_mask(all_pairs, excluded_pairs):
 
 
 @task()
-def generate_montage_metadata_table(subject, all_pairs, root):
-    return build_montage_metadata_table(subject, all_pairs, root=root)
+def generate_montage_metadata_table(subject, experiment, all_pairs, root):
+    return build_montage_metadata_table(subject, experiment, all_pairs,
+                                        root=root)
 
 
 @task()
-def get_pairs(subject, experiment, paths, localization=0, montage=0):
-    return get_pairs_core(subject, experiment, paths, localization=localization,
-                          montage=montage)
+def get_pairs(subject, experiment, paths):
+    return get_pairs_core(subject, experiment, paths)

--- a/ramutils/test/classifier/test_utils.py
+++ b/ramutils/test/classifier/test_utils.py
@@ -1,10 +1,10 @@
 import pytest
 import functools
 import numpy as np
-from sklearn.externals import joblib
 
 from pkg_resources import resource_filename
 from ramutils.classifier.utils import reload_classifier, train_classifier
+from ramutils.utils import load_event_test_data
 
 
 datafile = functools.partial(resource_filename,
@@ -40,9 +40,9 @@ def test_reload_classifier_rhino(rhino_root):
     'R1353N',
     'R1354E'
 ])
-def test_train_classifier(subject):
-    events = np.rec.array(np.load(datafile('/events/{}_task_events.npy'.format(
-        subject))))
+def test_train_classifier(subject, rhino_root):
+    events = load_event_test_data(datafile('/events/{}_task_events.npy'.format(
+        subject)), rhino_root)
     powers = np.load(datafile('/powers/{}_normalized_powers.npy'.format(
         subject)))
     weights = np.load(datafile('/weights/{}_sample_weights.npy'.format(

--- a/ramutils/test/classifier/test_weighting.py
+++ b/ramutils/test/classifier/test_weighting.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from pkg_resources import resource_filename
 from ramutils.parameters import FRParameters, PALParameters
+from ramutils.utils import load_event_test_data
 from ramutils.classifier.weighting import \
     determine_weighting_scheme_from_events, get_equal_weights, \
     get_fr_sample_weights, get_pal_sample_weights, get_sample_weights
@@ -18,8 +19,9 @@ datafile = functools.partial(resource_filename,
     ('R1354E_task_events.npy', 'FR'),
     ('R1353N_task_events.npy', 'PAL')
 ])
-def test_determine_weighting_scheme_from_events(event_file, exp_scheme):
-    events = np.rec.array(np.load(datafile('/events/' + event_file)))
+def test_determine_weighting_scheme_from_events(event_file, exp_scheme,
+                                                rhino_root):
+    events = load_event_test_data(datafile('/events/' + event_file), rhino_root)
     scheme = determine_weighting_scheme_from_events(events)
     assert scheme == exp_scheme
     return
@@ -31,8 +33,9 @@ def test_determine_weighting_scheme_from_events(event_file, exp_scheme):
     'R1353N_task_events.npy',
     'R1354E_task_events.npy'
 ])
-def test_get_equal_weights(event_file):
-    events = np.rec.array(np.load(datafile('/events/' + event_file)))
+def test_get_equal_weights(event_file, rhino_root):
+    events = load_event_test_data(datafile('/events/' + event_file),
+    rhino_root)
     weights = get_equal_weights(events)
     assert len(weights) == len(events)
     assert np.allclose(weights, 1)
@@ -42,8 +45,8 @@ def test_get_equal_weights(event_file):
 @pytest.mark.parametrize("event_file", [
     'R1350D_task_events.npy',
 ])
-def test_force_specific_weighting(event_file):
-    events = np.rec.array(np.load(datafile('/events/' + event_file)))
+def test_force_specific_weighting(event_file, rhino_root):
+    events = load_event_test_data(datafile('/events/' + event_file), rhino_root)
     weights = get_sample_weights(events, scheme='EQUAL')
     assert len(weights) == len(events)
     assert np.allclose(weights, 1)
@@ -59,9 +62,9 @@ def test_force_specific_weighting(event_file):
     'R1348J_task_events.npy',
     'R1354E_task_events.npy'
 ])
-def test_get_fr_sample_weights(event_file):
+def test_get_fr_sample_weights(event_file, rhino_root):
     # TODO: This check should be more robust
-    events = np.rec.array(np.load(datafile('/events/' + event_file)))
+    events = load_event_test_data(datafile('/events/' + event_file), rhino_root)
     weights = get_fr_sample_weights(events, 2.5)
     assert np.allclose(weights, 1) == False
     return
@@ -70,9 +73,10 @@ def test_get_fr_sample_weights(event_file):
 @pytest.mark.parametrize("event_file", [
     'R1353N_task_events.npy'
 ])
-def test_get_pal_sample_weights(event_file):
+def test_get_pal_sample_weights(event_file, rhino_root):
     # TODO: This check should be more robust
-    events = np.rec.array(np.load(datafile('/events/' + event_file)))
+    events = load_event_test_data(datafile('/events/' + event_file),
+                                  rhino_root)
     weights = get_pal_sample_weights(events, 7.2, 1.93)
     assert np.allclose(weights, 1) == False
     return
@@ -84,9 +88,10 @@ def test_get_pal_sample_weights(event_file):
     ('R1354E_task_events.npy', FRParameters),
     ('R1353N_task_events.npy', PALParameters)
 ])
-def test_get_sample_weights_blackbox(event_file, parameters):
+def test_get_sample_weights_blackbox(event_file, parameters, rhino_root):
     parameters = parameters().to_dict()
-    events = np.rec.array(np.load(datafile('/events/' + event_file)))
+    events = load_event_test_data(datafile('/events/' + event_file),
+                                  rhino_root)
     weights = get_sample_weights(events, **parameters)
 
     assert np.allclose(weights, 1) == False
@@ -100,9 +105,10 @@ def test_get_sample_weights_blackbox(event_file, parameters):
     ('R1354E_task_events.npy', 'R1354E_sample_weights.npy', FRParameters),
     ('R1353N_task_events.npy', 'R1353N_sample_weights.npy', PALParameters)
 ])
-def test_sample_weighting_regression(event_file, exp_weights, parameters):
+def test_sample_weighting_regression(event_file, exp_weights, parameters,
+                                     rhino_root):
     parameters = parameters().to_dict()
-    events = np.rec.array(np.load(datafile('/events/' + event_file)))
+    events = load_event_test_data(datafile('/events/' + event_file), rhino_root)
     current_weights = get_sample_weights(events, **parameters)
     old_weights = np.load(datafile('/weights/' + exp_weights))
 

--- a/ramutils/test/conftest.py
+++ b/ramutils/test/conftest.py
@@ -18,6 +18,7 @@ def output_dest(request):
     return request.config.getoption("--output-dest")
 
 
+
 def pytest_generate_tests(metafunc):
     if 'rhino' in metafunc.fixturenames:
         metafunc.parametrize("rhino",

--- a/ramutils/test/tasks/test_classifier.py
+++ b/ramutils/test/tasks/test_classifier.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from ramutils.parameters import FRParameters, PALParameters
 from ramutils.tasks.classifier import perform_cross_validation
+from ramutils.utils import load_event_test_data
 
 from pkg_resources import resource_filename
 from sklearn.externals import joblib
@@ -20,9 +21,10 @@ class TestCrossValidation:
         ('R1353N', PALParameters),  # pal
         ('R1354E', FRParameters)  # fr and catfr
     ])
-    def test_perform_cross_validation_regression(self, subject, params):
-        # Note: These expected outputs will change if *any* of the inputs change,
-        #  i.e. classifier, powers, events, or parameters
+    def test_perform_cross_validation_regression(self, subject, params,
+                                                 rhino_root):
+        # Note: These expected outputs will change if *any* of the inputs
+        # change, i.e. classifier, powers, events, or parameters
         expected_output = {
             'R1350D': 0.5205,
             'R1353N': 0.8790,
@@ -33,8 +35,8 @@ class TestCrossValidation:
             datafile('/classifiers/{}_trained_classifier.pkl'.format(subject)))
         powers = np.load(
             datafile('/powers/{}_normalized_powers.npy'.format(subject)))
-        events = np.rec.array(np.load(
-            datafile('/events/{}_task_events.npy'.format(subject))))
+        events = load_event_test_data(
+            datafile('/events/{}_task_events.npy'.format(subject)), rhino_root)
         classifier_summary = perform_cross_validation(classifier, powers,
                                                       events, 10 ,
                                                       tag='test',
@@ -48,9 +50,10 @@ class TestCrossValidation:
         ('R1353N', PALParameters),  # pal
         ('R1354E', FRParameters)  # fr and catfr
     ])
-    def test_perform_lolo_cross_validation_regression(self, subject, params):
-        # Note: These expected outputs will change if *any* of the inputs change,
-        #  i.e. classifier, powers, events, or parameters
+    def test_perform_lolo_cross_validation_regression(self, subject, params,
+                                                      rhino_root):
+        # Note: These expected outputs will change if *any* of the inputs
+        # change, i.e. classifier, powers, events, or parameters
         expected_output = {
             'R1350D': 0.5097,
             'R1353N': 0.7352,
@@ -61,8 +64,8 @@ class TestCrossValidation:
             datafile('/classifiers/{}_trained_classifier.pkl'.format(subject)))
         powers = np.load(
             datafile('/powers/{}_normalized_powers.npy'.format(subject)))
-        events = np.rec.array(np.load(
-            datafile('/events/{}_task_events.npy'.format(subject))))
+        events = load_event_test_data(
+            datafile('/events/{}_task_events.npy'.format(subject)), rhino_root)
 
         # Select just the first session so that lolo cross validation is used
         sessions = np.unique(events.session)

--- a/ramutils/test/tasks/test_events.py
+++ b/ramutils/test/tasks/test_events.py
@@ -5,6 +5,7 @@ import numpy as np
 from pkg_resources import resource_filename
 
 from ramutils.tasks import memory
+from ramutils.utils import load_event_test_data
 from ramutils.tasks.events import *
 from ramutils.parameters import FRParameters, PALParameters, FilePaths
 
@@ -25,9 +26,10 @@ class TestEvents:
         ('R1353N', 'PAL1', PALParameters),
         ('R1348J', 'catFR1', FRParameters)
     ])
-    def test_training_legacy_regression(self, subject, experiment, params, rhino_root):
+    def test_training_legacy_regression(self, subject, experiment, params,
+                                        rhino_root):
         expected = datafile("/{}_task_events_rhino.npy".format(subject))
-        expected_events = np.rec.array(np.load(expected))
+        expected_events = load_event_test_data(expected, rhino_root)
 
         paths = FilePaths(root=rhino_root)
         extra_kwargs = params().to_dict()
@@ -36,7 +38,6 @@ class TestEvents:
         assert len(actual_events) == len(expected_events)
         assert np.array_equal(actual_events.recalled,
                               expected_events.recalled)
-
 
     @pytest.mark.rhino
     @pytest.mark.parametrize('subject, experiment, params, combine_events', [
@@ -60,7 +61,7 @@ class TestEvents:
         current_events = build_training_data(subject, experiment, paths,
                                              **extra_kwargs).compute()
 
-        expected_events = np.rec.array(np.load(expected))
+        expected_events = load_event_test_data(expected, rhino_root)
         assert len(current_events) == len(expected_events)
         assert np.array_equal(current_events.recalled, expected_events.recalled)
 
@@ -93,7 +94,7 @@ class TestEvents:
             subject, experiment, paths, joint_report=joint_report,
             sessions=sessions, **extra_kwargs).compute()
 
-        expected_events = np.rec.array(np.load(expected))
+        expected_events = load_event_test_data(expected, rhino_root)
         assert len(expected_events) == len(task_events)
         assert np.array_equal(task_events.recalled, expected_events.recalled)
 

--- a/ramutils/test/test_montage.py
+++ b/ramutils/test/test_montage.py
@@ -120,8 +120,6 @@ class TestMontage:
     def test_load_pairs_from_json(self, subject):
         test_pairs = load_pairs_from_json(subject, 'FR1', rootdir=datafile(''))
         assert len(test_pairs.keys()) > 10
-        with open('/Users/zduey/Desktop/pairs.json', 'w') as f:
-            f.write(json.dumps(test_pairs))
         assert '11LD1-11LD2' in test_pairs
 
         return

--- a/ramutils/test/test_montage.py
+++ b/ramutils/test/test_montage.py
@@ -118,21 +118,10 @@ class TestMontage:
         'R1354E',
     ])
     def test_load_pairs_from_json(self, subject):
-        test_pairs = load_pairs_from_json(subject, rootdir=datafile(''))
-        assert len(test_pairs.keys()) > 0
-        assert '11LD1-11LD2' in test_pairs
-
-        test_pairs = load_pairs_from_json(subject,
-                                          localization=0,
-                                          rootdir=datafile(''))
-        assert len(test_pairs.keys()) > 0
-        assert '11LD1-11LD2' in test_pairs
-
-        test_pairs = load_pairs_from_json(subject,
-                                          localization=0,
-                                          montage=0,
-                                          rootdir=datafile(''))
-        assert len(test_pairs.keys()) > 0
+        test_pairs = load_pairs_from_json(subject, 'FR1', rootdir=datafile(''))
+        assert len(test_pairs.keys()) > 10
+        with open('/Users/zduey/Desktop/pairs.json', 'w') as f:
+            f.write(json.dumps(test_pairs))
         assert '11LD1-11LD2' in test_pairs
 
         return
@@ -144,7 +133,9 @@ class TestMontage:
         with open(datafile('/input/configs/{}_pairs_from_ec.json'.format(subject))) as f:
             pairs_from_ec = json.load(f)
 
-        metadata_table = build_montage_metadata_table(subject, pairs_from_ec,
+        metadata_table = build_montage_metadata_table(subject,
+                                                      'FR1',
+                                                      pairs_from_ec,
                                                       root=datafile(''))
         assert len(metadata_table) == len(pairs_from_ec[subject]['pairs'].keys())
 
@@ -157,11 +148,16 @@ class TestMontage:
         with open(datafile('/input/configs/{}_pairs_from_ec.json'.format(subject))) as f:
             pairs_from_ec = json.load(f)
 
-        metadata_table = build_montage_metadata_table(subject, pairs_from_ec, root=datafile(''))
-        old_metadata_table = pd.read_csv(datafile('/input/montage/{}_montage_metadata.csv'.format(subject)))
+        metadata_table = build_montage_metadata_table(subject,
+                                                      'FR1',
+                                                      pairs_from_ec,
+                                                      root=datafile(''))
+        old_metadata_table = pd.read_csv(
+            datafile('/input/montage/{}_montage_metadata.csv'.format(subject)))
 
         # Check correspondence my merging
-        merged = metadata_table.merge(old_metadata_table, how='outer', indicator=True)
+        merged = metadata_table.merge(old_metadata_table, how='outer',
+                                      indicator=True)
         assert 'left_only' not in merged._merge
         assert 'right_only' not in merged._merge
 
@@ -170,12 +166,14 @@ class TestMontage:
     @pytest.mark.rhino
     @pytest.mark.parametrize('subject, experiment', [
         ('R1375C', 'catFR1'), # Will use electrode config
-        ('R1320D', 'catFR1') # Will fall back to pairs.json
+        ('R1320D', 'catFR1'), # Will fall back to pairs.json
+        ('R1279P', 'catFR1'), # Falls back to pairs.json, updated subject needed
     ])
     def test_get_pairs(self, subject, experiment, rhino_root):
         paths = FilePaths(root=rhino_root)
         pairs = get_pairs(subject, experiment, paths)
         assert len(pairs.keys()) > 0
+        assert pairs[subject] is not None
 
         return
 
@@ -184,6 +182,7 @@ class TestMontage:
                           electrode_config_file='/input/configs/R1354E_26OCT2017L0M0STIM.csv',
                           pairs='/input/montage/R1354E_pairs.json')
         config_pairs = generate_pairs_from_electrode_config('R1354E',
+                                                            'FR1',
                                                             paths)
         assert len(config_pairs['R1354E']['pairs'].keys()) > 0
         return

--- a/ramutils/utils.py
+++ b/ramutils/utils.py
@@ -4,7 +4,7 @@ from functools import wraps
 import json
 import os
 from timeit import default_timer
-
+import numpy as np
 import h5py
 
 from ramutils.log import get_logger
@@ -254,3 +254,16 @@ def bytes_to_str(istring, encoding='utf-8'):
         return istring.decode(encoding=encoding)
     else:
         return istring
+
+
+def load_event_test_data(datapath, rootdir):
+    """
+        Modify the path stored in the eegfile field to work with any given
+        root directory at runtime. Used in test data suite to allow running
+        tests rom an arbitrary location that has access to RHINO
+    """
+    events = np.rec.array(np.load(datapath))
+    events['eegfile'] = [path.replace('/Volumes/RHINO/', rootdir) for path in
+                         events['eegfile']]
+
+    return events


### PR DESCRIPTION
Added a utility function for loading event test data and updating the mount point in the 'eegfile' field. This will allow the full test suite to be run from any machine, and not just the machine where the test events were first used. Ultimately, this is necessary because PTSA modified the eegfile field of an event recarray based on the given mount point. See: https://github.com/pennmem/ptsa_new/issues/122