### PR TITLE
Include data/ directory when building the package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include *.rst
 include *.txt
+include ramutils/data/*
 recursive-exclude MatlabIO *
 recursive-include ramutils *.html *.js *.css


### PR DESCRIPTION
Tests failed when running using the conda package because a .npy file that is needed for calculating modal controllability was accidentally left out of the build process