### PR TITLE
Change default behavior of caching

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Upcoming
 --------
 
 * store all underlying data necessary for building reports to facilitate quick reload #118
+* do not use cached intermediate results be default (force-rerun)
+* clear memory on successful completion of report build
 
 Version 2.1.3
 -------------

--- a/ramutils/cli/__init__.py
+++ b/ramutils/cli/__init__.py
@@ -23,7 +23,8 @@ class RamArgumentParser(ArgumentParser):
         self.add_argument('--cachedir', default=default_cache_dir,
                           help='absolute path for caching dir')
         self.add_argument('--subject', '-s', required=True, type=str, help='subject ID')
-        self.add_argument('--force-rerun', action='store_true', help='force re-running all tasks')
+        self.add_argument('--use_cached', action='store_true',
+                          help='allow cached results from previous run to be reused')
         self.add_argument('--experiment', '-x', required=True, type=str,
                           choices=allowed_experiments, help='experiment')
         self.add_argument('--vispath', default=None, type=str,
@@ -42,15 +43,15 @@ class RamArgumentParser(ArgumentParser):
                 pass
 
     @staticmethod
-    def _configure_caching(cachedir, invalidate=False):
+    def _configure_caching(cachedir, use_cached=False):
         """Setup task caching.
 
         Parameters
         ----------
         cachedir : str
             Location to cache task outputs to.
-        invalidate : bool
-            Clear all cached files.
+        use_cached : bool
+            Use cached results from previous runs
 
         Returns
         -------
@@ -61,7 +62,7 @@ class RamArgumentParser(ArgumentParser):
 
         memory.cachedir = cachedir
 
-        if invalidate and os.path.isdir(cachedir):
+        if not use_cached and os.path.isdir(cachedir):
             memory.clear()
 
         return memory
@@ -70,7 +71,7 @@ class RamArgumentParser(ArgumentParser):
         args = super(RamArgumentParser, self).parse_args(args, namespace)
         self._create_dirs(args.dest)
         self._create_dirs(args.cachedir)
-        self._configure_caching(args.cachedir, args.force_rerun)
+        self._configure_caching(args.cachedir, args.use_cached)
         return args
 
 

--- a/ramutils/cli/expconf.py
+++ b/ramutils/cli/expconf.py
@@ -11,6 +11,8 @@ from ramutils.cli import make_parser, ValidationError
 from ramutils.constants import EXPERIMENTS
 from ramutils.log import get_logger, get_warning_accumulator
 from ramutils.utils import timer
+from ramutils.tasks import memory
+
 
 # Supported experiments
 experiments = (
@@ -168,6 +170,7 @@ def create_expconf(input_args=None):
                               localization=args.localization,
                               montage=args.montage,
                               default_surface_area=default_surface_area)
+        memory.clear() # clear cached intermediate results on successful build
 
     warnings = '\n' + warning_accumulator.format_all()
     if warnings is not None:

--- a/ramutils/cli/report.py
+++ b/ramutils/cli/report.py
@@ -26,8 +26,8 @@ parser.add_argument('--excluded-contacts', '-E', nargs='+',
                     help='contacts to exclude from classifier')
 parser.add_argument('--joint-report', '-j', action='store_true', default=False,
                     help='include CatFR/FR for FR reports (default: off)')
-parser.add_argument('--use-cached', '-C', action="store_true", default=True,
-                    help='use previously generated data')
+parser.add_argument('--rerun', '-C', action="store_true", default=False,
+                    help='do not use previously generated output')
 parser.add_argument('--report_db_location',
                     help='location of report data database',
                     type=str, default="/scratch/report_database/")
@@ -85,7 +85,7 @@ def create_report(input_args=None):
             exp_params=exp_params,
             sessions=sessions,
             vispath=args.vispath,
-            use_cached=args.use_cached
+            rerun=args.rerun
         )
         logger.info("Wrote report to %s\n", path)
 

--- a/ramutils/cli/report.py
+++ b/ramutils/cli/report.py
@@ -16,6 +16,8 @@ from ramutils.montage import make_stim_params
 from ramutils.parameters import FilePaths, FRParameters
 from ramutils.pipelines.report import make_report
 from ramutils.utils import timer, is_stim_experiment
+from ramutils.tasks import memory
+
 
 parser = make_parser("Generate a report")
 parser.add_argument('--sessions', '-S', nargs='+',
@@ -88,6 +90,7 @@ def create_report(input_args=None):
             rerun=args.rerun
         )
         logger.info("Wrote report to %s\n", path)
+        memory.clear() # remove cached intermediate results if build succeeds
 
     warnings = '\n' + warning_accumulator.format_all()
     if warnings is not None:

--- a/ramutils/pipelines/report.py
+++ b/ramutils/pipelines/report.py
@@ -7,7 +7,7 @@ from ramutils.tasks import *
 
 def make_report(subject, experiment, paths, joint_report=False,
                 retrain=False, stim_params=None, exp_params=None,
-                sessions=None, vispath=None, use_cached=True):
+                sessions=None, vispath=None, rerun=False):
     """Run a report.
 
     Parameters
@@ -31,8 +31,8 @@ def make_report(subject, experiment, paths, joint_report=False,
         When not given, all available sessions are used for reports.
     vispath : str
         Filename for task graph visualization.
-    use_cached: bool
-        If True, attempt to load data from long-term storage. If any
+    rerun: bool
+        If True, do not attempt to load data from long-term storage. If any
         necessary data is not found, everything will be rerun
 
     Returns
@@ -57,7 +57,7 @@ def make_report(subject, experiment, paths, joint_report=False,
 
     # PS runs so quickly and has a much more nested event structure, so it is
     # better to always just re-run
-    if use_cached and 'PS' not in experiment:
+    if not rerun and 'PS' not in experiment:
         target_selection_table, classifier_evaluation_results, \
         session_summaries, math_summaries = load_existing_results(subject,
                                                                   experiment,

--- a/ramutils/test/reports/test_summary.py
+++ b/ramutils/test/reports/test_summary.py
@@ -173,11 +173,6 @@ class TestFRSessionSummary:
         probs = np.random.random(len(events))
         cls.summary.populate(events, probs)
 
-    def test_no_probs_given(self, fr5_events):
-        summary = FRSessionSummary()
-        summary.populate(fr5_events)
-        assert all(summary.prob == -999)
-
     def test_num_lists(self):
         assert self.summary.num_lists == 25
 

--- a/ramutils/test/test_cli.py
+++ b/ramutils/test/test_cli.py
@@ -139,7 +139,7 @@ class TestCreateReports:
     @pytest.mark.rhino
     @pytest.mark.slow
     @pytest.mark.output
-    @pytest.mark.parametrize('use_cached', [False, True])
+    @pytest.mark.parametrize('rerun', [True, False])
     @pytest.mark.parametrize('subject, experiment, sessions, joint', [
         ('R1001P', 'FR1', None, False),
         ('R1354E', 'FR1', [0], False),
@@ -151,7 +151,7 @@ class TestCreateReports:
         ('R1374T', 'CatFR1', None, True),
     ])
     def test_create_open_loop_report(self, subject, experiment, sessions,
-                                     joint, use_cached, rhino_root,
+                                     joint, rerun, rhino_root,
                                      output_dest):
         args = [
             '--root', rhino_root,
@@ -161,8 +161,8 @@ class TestCreateReports:
             '--report_db_location', output_dest
         ]
 
-        if use_cached is False:
-            args += ['-C']
+        if rerun is True:
+            args += ['--rerun']
 
         if joint:
             args += ['-j']
@@ -175,14 +175,14 @@ class TestCreateReports:
 
     @pytest.mark.rhino
     @pytest.mark.output
-    @pytest.mark.parametrize('use_cached', [False, True])
+    @pytest.mark.parametrize('rerun', [True, False])
     @pytest.mark.parametrize('subject, experiment, sessions', [
         ('R1374T', 'CatFR5', [0]),
         ('R1345D', 'FR5', [0]),
         ('R1374T', 'PS4_CatFR5', None)
     ])
     def test_create_stim_session_report(self, subject, experiment, sessions,
-                                        use_cached, rhino_root, output_dest):
+                                        rerun, rhino_root, output_dest):
 
         args = [
             '--root', rhino_root,
@@ -192,8 +192,8 @@ class TestCreateReports:
             '--report_db_location', output_dest
         ]
 
-        if use_cached is False:
-            args += ['-C']
+        if rerun is True:
+            args += ['--rerun']
 
         if sessions is not None:
             args += ['-S'] + sessions

--- a/ramutils/test/test_cli.py
+++ b/ramutils/test/test_cli.py
@@ -17,8 +17,8 @@ def test_make_parser():
     assert args.experiment == 'FR1'
 
 
-@pytest.mark.parametrize('invalidate', [True, False])
-def test_configure_caching(invalidate, tmpdir):
+@pytest.mark.parametrize('use_cached', [True, False])
+def test_configure_caching(use_cached, tmpdir):
     from ramutils.tasks import memory
 
     path = str(tmpdir)
@@ -34,12 +34,12 @@ def test_configure_caching(invalidate, tmpdir):
     assert len(os.listdir(path))
 
     # Re-configure, possibly clearing
-    RamArgumentParser._configure_caching(path, invalidate)
+    RamArgumentParser._configure_caching(path, use_cached)
 
-    if invalidate:
-        assert not len(os.listdir(path))
-    else:
+    if use_cached:
         assert len(os.listdir(path))
+    else:
+        assert not len(os.listdir(path))
 
 
 class TestExpConf:


### PR DESCRIPTION
Previous default was to use cached intermediate results (done by joblib) when building reports. New behavior is to rebuild by default and allow the user to override this behavior. Additionally, if building a report or config file succeeds, the intermediate results are cleared out to prevent potential conflicts later on.