### PR TITLE
Hmm workaround

### DIFF
--- a/ramutils/hmm.py
+++ b/ramutils/hmm.py
@@ -151,11 +151,10 @@ def save_traceplot(trace, full_path):
     return
 
 
-def save_foresplot(trace, title, full_path):
+def save_foresplot(trace, full_path):
     stim_variable = "Stim Effect (Across Sessions)"
     ax = pm.forestplot(trace,
                        varnames=[stim_variable],
-                       main=title,
                        xtitle="Estimated Effect of Stimulation",
                        quartiles=False,
                        plot_kwargs=dict(

--- a/ramutils/hmm.py
+++ b/ramutils/hmm.py
@@ -156,6 +156,7 @@ def save_foresplot(trace, full_path):
     ax = pm.forestplot(trace,
                        varnames=[stim_variable],
                        xtitle="Estimated Effect of Stimulation",
+                       ylabels=[''],
                        quartiles=False,
                        plot_kwargs=dict(
                            linewidth=5,

--- a/ramutils/hmm.py
+++ b/ramutils/hmm.py
@@ -1,5 +1,9 @@
+import matplotlib as mpl
+mpl.use('Agg') # allows matplotlib to work without x-windows (for RHINO)
+
 import pymc3 as pm
 import pandas as pd
+import matplotlib.pyplot as plt
 
 
 class HierarchicalModel(object):
@@ -132,3 +136,38 @@ class HierarchicalModel(object):
 
     def _fit_catFR5_model(self, draws, tune):
         return self._fit_FR3_model(draws, tune)
+
+
+def save_traceplot(trace, full_path):
+    stim_variable = "Stim Effect (Across Sessions)"
+    line_dict = dict(zip(stim_variable, [0]))
+    ax = pm.traceplot(trace, lines=line_dict)
+    plt.savefig(full_path,
+                format="png",
+                dpi=300,
+                bbox_inchces="tight",
+                pad_inches=.1)
+    plt.close()
+    return
+
+
+def save_foresplot(trace, title, full_path):
+    stim_variable = "Stim Effect (Across Sessions)"
+    ax = pm.forestplot(trace,
+                       varnames=[stim_variable],
+                       main=title,
+                       xtitle="Estimated Effect of Stimulation",
+                       quartiles=False,
+                       plot_kwargs=dict(
+                           linewidth=5,
+                           color='#136ba5',
+                           markersize=6,
+                           fontsize=12)
+                       )
+    plt.savefig(full_path,
+                format="png",
+                dpi=300,
+                bbox_inches="tight",
+                pad_inches=0.1)
+    plt.close()
+    return

--- a/ramutils/pipelines/report.py
+++ b/ramutils/pipelines/report.py
@@ -66,12 +66,9 @@ def make_report(subject, experiment, paths, joint_report=False,
 
     if not rerun:
         target_selection_table, classifier_evaluation_results, \
-        session_summaries, math_summaries = load_existing_results(subject,
-                                                                  experiment,
-                                                                  sessions,
-                                                                  stim_report,
-                                                                  paths.data_db,
-                                                                  rootdir=paths.root).compute()
+        session_summaries, math_summaries, hmm_results = \
+            load_existing_results(subject, experiment, sessions, stim_report,
+                                  paths.data_db, rootdir=paths.root).compute()
 
         # Check if only None values were returned. Processing will continue
         # undeterred
@@ -82,7 +79,8 @@ def make_report(subject, experiment, paths, joint_report=False,
         else:
             report = build_static_report(subject, experiment, session_summaries,
                                          math_summaries, target_selection_table,
-                                         classifier_evaluation_results, paths.dest)
+                                         classifier_evaluation_results,
+                                         paths.dest, hmm_results=hmm_results)
             return report.compute()
 
     # TODO: allow using different localization, montage numbers
@@ -154,7 +152,8 @@ def make_report(subject, experiment, paths, joint_report=False,
 
     report = build_static_report(subject, experiment, session_summaries,
                                  math_summaries, target_selection_table,
-                                 classifier_evaluation_results, paths.dest)
+                                 classifier_evaluation_results,
+                                 hmm_results=output, dest=paths.dest)
 
     if vispath is not None:
         report.visualize(filename=vispath)

--- a/ramutils/pipelines/report.py
+++ b/ramutils/pipelines/report.py
@@ -117,7 +117,8 @@ def make_report(subject, experiment, paths, joint_report=False,
 
     if not stim_report:
         session_summaries, math_summaries, target_selection_table, \
-        classifier_evaluation_results, repetition_ratio_dict = \
+        classifier_evaluation_results, repetition_ratio_dict, \
+        behavioral_results = \
             generate_data_for_nonstim_report(subject, experiment, sessions,
                                              joint_report, paths, ec_pairs,
                                              used_pair_mask, excluded_pairs,
@@ -125,7 +126,8 @@ def make_report(subject, experiment, paths, joint_report=False,
                                              **kwargs)
     elif experiment.find("PS5") != -1:
         session_summaries, math_summaries, \
-        classifier_evaluation_results, repetition_ratio_dict = \
+        classifier_evaluation_results, repetition_ratio_dict, \
+        behavioral_results = \
             generate_data_for_ps5_report(subject, experiment, joint_report,
                                          pairs_metadata_table,
                                          trigger_electrode, ec_pairs,
@@ -135,7 +137,8 @@ def make_report(subject, experiment, paths, joint_report=False,
 
     # Non-PS5 stim session
     else:
-        session_summaries, math_summaries, classifier_evaluation_results = \
+        session_summaries, math_summaries, classifier_evaluation_results, \
+        behavioral_results = \
             generate_data_for_stim_report(subject, experiment, joint_report,
                                           retrain, paths, ec_pairs,
                                           used_pair_mask, final_pairs,
@@ -143,9 +146,10 @@ def make_report(subject, experiment, paths, joint_report=False,
                                           task_events, stim_data, **kwargs)
 
     output = save_all_output(subject, experiment, session_summaries,
-                             math_summaries, target_selection_table,
-                             classifier_evaluation_results,
-                             paths.data_db).compute()
+                             math_summaries, classifier_evaluation_results,
+                             paths.data_db,
+                             target_selection_table=target_selection_table,
+                             behavioral_results=behavioral_results).compute()
 
     report = build_static_report(subject, experiment, session_summaries,
                                  math_summaries, target_selection_table,
@@ -263,7 +267,7 @@ def generate_data_for_nonstim_report(subject, experiment, sessions,
                                      joint_classifier_summary]
 
     return session_summaries, math_summaries, target_selection_table, \
-           classifier_evaluation_results, repetition_ratio_dict
+           classifier_evaluation_results, repetition_ratio_dict, None
 
 
 def generate_data_for_ps5_report(subject, experiment, joint_report,
@@ -310,7 +314,7 @@ def generate_data_for_ps5_report(subject, experiment, joint_report,
     classifier_evaluation_results = []
 
     return session_summaries, math_summaries, classifier_evaluation_results, \
-           repetition_ratio_dict
+           repetition_ratio_dict, None
 
 
 def generate_data_for_stim_report(subject, experiment, joint_report, retrain,
@@ -392,12 +396,11 @@ def generate_data_for_stim_report(subject, experiment, joint_report, retrain,
 
     math_summaries = summarize_math(all_events, joint=joint_report)
 
-    # TODO: Commented out until we have a clean way to plot results from
-    # the traces
-    # behavioral_results = estimate_effects_of_stim(subject, experiment,
-    #     session_summaries).compute()
+    behavioral_results = estimate_effects_of_stim(subject, experiment,
+        session_summaries)
 
     classifier_evaluation_results = post_hoc_results[
         'classifier_summaries']
-    return session_summaries, math_summaries, classifier_evaluation_results
+    return session_summaries, math_summaries, classifier_evaluation_results, \
+           behavioral_results
 

--- a/ramutils/pipelines/report.py
+++ b/ramutils/pipelines/report.py
@@ -141,9 +141,10 @@ def make_report(subject, experiment, paths, joint_report=False,
         behavioral_results = \
             generate_data_for_stim_report(subject, experiment, joint_report,
                                           retrain, paths, ec_pairs,
-                                          used_pair_mask, final_pairs,
-                                          pairs_metadata_table, all_events,
-                                          task_events, stim_data, **kwargs)
+                                          excluded_pairs, used_pair_mask,
+                                          final_pairs, pairs_metadata_table,
+                                          all_events, task_events, stim_data,
+                                          **kwargs)
 
     output = save_all_output(subject, experiment, session_summaries,
                              math_summaries, classifier_evaluation_results,

--- a/ramutils/reports/generate.py
+++ b/ramutils/reports/generate.py
@@ -50,7 +50,7 @@ class ReportGenerator(object):
 
     """
     def __init__(self, session_summaries, math_summaries,
-                 sme_table, classifier_summaries, dest='.'):
+                 sme_table, classifier_summaries, hmm_results={}, dest='.'):
         self.session_summaries = session_summaries
         self.math_summaries = math_summaries
         self.sme_table = sme_table
@@ -60,6 +60,7 @@ class ReportGenerator(object):
                               self.session_summaries]
         self.catfr_summaries = list(compress(self.session_summaries, catfr_summary_mask))
         self.subject = extract_subject(self.session_summaries[0].events)
+        self.hmm_results = hmm_results
 
         # PS has not math summaries, so only check for non-PS experiments
         if all(['PS' not in exp for exp in self.experiments]):
@@ -255,6 +256,7 @@ class ReportGenerator(object):
             classifiers=self.classifiers,
             stim_params=self.session_summaries[0].stim_parameters,
             recall_tests=self.session_summaries[0].recall_test_results,
+            hmm_results=self.hmm_results,
             plot_data={
                 'roc': json.dumps({
                     'fpr': [classifier.false_positive_rate for classifier in self.classifiers],

--- a/ramutils/reports/summary.py
+++ b/ramutils/reports/summary.py
@@ -786,6 +786,7 @@ class FRStimSessionSummary(FRSessionSummary, StimSessionSummary):
                      .rename(columns={'is_stim_item': 'n_stimulations',
                                       'subject': 'n_trials'})
                      .reset_index())
+        grouped['amplitude'] = grouped['amplitude'] / 1000.0
 
         return list(grouped.T.to_dict().values())
 

--- a/ramutils/reports/templates/fr5.html
+++ b/ramutils/reports/templates/fr5.html
@@ -11,5 +11,6 @@
 {% include 'serialpos_curve.html' %}
 {% include 'classifier.html' %}
 {% include 'stim_recall_analysis.html' %}
+{% include 'hmm.html' %}
 {% include 'data_quality.html' %}
 {% endblock %}

--- a/ramutils/reports/templates/hmm.html
+++ b/ramutils/reports/templates/hmm.html
@@ -1,0 +1,31 @@
+<div>
+  <h2>Estimated Effect of Stimulation</h2>
+  <figure>
+  <div class="row">
+      <div class="col-md-4">
+        <figure>
+          <img class="img-thumbnail" src="{{ hmm_results['list'] }}">
+          <figcaption>Stim Lists vs. Non-Stim Lists</figcaption>
+        </figure>
+      </div>
+       <div class="col-md-4">
+        <figure>
+          <img class="img-thumbnail" src="{{ hmm_results['stim_item'] }}">
+          <figcaption>Stim Items vs. Low Biomarker Non-Stim Items</figcaption>
+        </figure>
+      </div>
+      <div class="col-md-4">
+        <figure>
+          <img class="img-thumbnail" src="{{ hmm_results['post_stim_item'] }}">
+          <figcaption>Post-Stim Items vs. Low Biomarker Non-Stim Items</figcaption>
+        </figure>
+      </div>
+  </div>
+    <figcaption>
+        Filled circles represent point estimates for the effect of stimulation, while horizontal lines are the
+        95% credible intervals. To get odds ratios from the point estimates, calcualte eβ where β is the coefficient of
+        interest. Estimates come from a hierarchical model predicting word-level recall from stimulation controlling for
+        serial position effects. The model is fit using MCMC sampling with 5,000 draws.
+    </figcaption>
+  </figure>
+</div>

--- a/ramutils/tasks/behavioral_analysis.py
+++ b/ramutils/tasks/behavioral_analysis.py
@@ -30,7 +30,7 @@ def estimate_effects_of_stim(subject, experiment, stim_session_summaries):
 
 
     """
-    result_traces = []
+    result_traces = {}
 
     session_dataframes = []
     for session_summary in stim_session_summaries:
@@ -58,7 +58,7 @@ def estimate_effects_of_stim(subject, experiment, stim_session_summaries):
     stim_list_model = HierarchicalModel(df, subject, experiment,
                                         item_comparison='list')
     stim_list_trace = stim_list_model.fit()
-    result_traces.append(stim_list_trace)
+    result_traces['list'] = stim_list_trace
 
     # Stim items vs. low bio non stim items
     stim_or_low_bio_df = df[((df["is_stim_item"] == True) |
@@ -69,7 +69,7 @@ def estimate_effects_of_stim(subject, experiment, stim_session_summaries):
                                         experiment,
                                         item_comparison='stim')
     stim_item_trace = stim_item_model.fit()
-    result_traces.append(stim_item_trace)
+    result_traces['stim_item'] = stim_item_trace
 
     # Post Stim Items vs. Low Biomarker Non-stim Items
     post_stim_or_low_bio_df = df[((df["is_post_stim_item"] == True) |
@@ -80,7 +80,7 @@ def estimate_effects_of_stim(subject, experiment, stim_session_summaries):
                                              experiment,
                                              item_comparison='post_stim')
     post_stim_item_trace = post_stim_item_model.fit()
-    result_traces.append(post_stim_item_trace)
+    result_traces['post_stim_item'] = post_stim_item_trace
 
     return result_traces
 

--- a/ramutils/tasks/misc.py
+++ b/ramutils/tasks/misc.py
@@ -12,6 +12,7 @@ from ramutils.utils import get_session_str
 
 from ._wrapper import task
 from ramutils.reports.summary import *
+from ramutils.hmm import save_foresplot, save_traceplot
 from ramutils.utils import is_stim_experiment as is_stim_experiment_core
 from ramutils.utils import get_completed_sessions
 from ramutils.log import get_logger
@@ -47,8 +48,8 @@ def is_stim_experiment(experiment):
 
 @task(cache=False)
 def save_all_output(subject, experiment, session_summaries, math_summaries,
-                    target_selection_table, classifier_evaluation_results,
-                    save_location):
+                    classifier_evaluation_results, save_location,
+                    target_selection_table=None, behavioral_results=None):
 
     base_output_format = os.path.join(save_location,
                                       "{subject}_{experiment}_{session}_{"
@@ -85,6 +86,24 @@ def save_all_output(subject, experiment, session_summaries, math_summaries,
             subject=subject, experiment=experiment, session=session_str,
             data_type='classifier_' + classifier_summary.tag,
             file_type='h5'))
+
+    # Save plots from hmm models
+    if behavioral_results is not None:
+        for name, trace in behavioral_results.items():
+            full_path = base_output_format.format(subject=subject,
+                                                  experiment=experiment,
+                                                  session=session_str,
+                                                  data_type=(name +
+                                                             '_foresplot'),
+                                                  file_type='png')
+            save_foresplot(trace, full_path)
+            full_path = base_output_format.format(subject=subject,
+                                                  experiment=experiment,
+                                                  session=session_str,
+                                                  data_type=(name +
+                                                             '_traceplot'),
+                                                  file_type='png')
+            save_traceplot(trace, full_path)
 
     return True
 

--- a/ramutils/tasks/reports.py
+++ b/ramutils/tasks/reports.py
@@ -11,11 +11,12 @@ __all__ = [
 
 @task(cache=False)
 def build_static_report(subject, experiment, session_summaries, math_summaries,
-                        delta_hfa_table, classifier_summaries, dest):
+                        delta_hfa_table, classifier_summaries, dest,
+                        hmm_results={}):
     """ Given a set of summary objects, generate a static HTML report """
     generator = ReportGenerator(session_summaries, math_summaries,
                                 delta_hfa_table, classifier_summaries,
-                                dest=dest)
+                                dest=dest, hmm_results=hmm_results)
     report = generator.generate()
 
     sessions = [str(summary.session_number) for summary in session_summaries]


### PR DESCRIPTION
The pymc3 bayesian hierarchical multilevel models use matplotlib for plotting so initially they were not included in the html-based report release. This PR creates a workaround so the model results can still be included in the reports, but ultimately just involves saving images of the results and loading those images in the reports