### PR TITLE
Exclude sessions

### DIFF
--- a/ramutils/events.py
+++ b/ramutils/events.py
@@ -50,7 +50,7 @@ def load_events(subject, experiment, file_type='all_events',
                                                "protocols",
                                                "r1.json"))
 
-    sessions_to_load = sessions
+    sessions_to_load = extract_relevant_sessions(experiment, sessions)
     if sessions_to_load is None:
         sessions_to_load = get_completed_sessions(subject, experiment,
                                                   rootdir=rootdir)
@@ -79,7 +79,6 @@ def load_events(subject, experiment, file_type='all_events',
         empty_recarray = initialize_empty_event_reccarray()
         return empty_recarray
 
-    # TODO: Make this less ugly to look at
     events = np.rec.array(np.concatenate([
         BaseEventReader(filename=f, eliminate_events_with_no_eeg=True).read()
         for f in event_files]))
@@ -189,26 +188,29 @@ def clean_events(events, start_time=None, end_time=None, duration=None,
     return events
 
 
-def remove_sessions(events, excluded_sessions):
-    """ Remove the requested sessions from the events
-
-    Parameters:
-    -----------
-    excluded_sessions: List[int]
-        List of session numbers to exclude. Convention is to start at 0 for FR, 100 for catFR, and 200 for PAL
-
-    Returns:
-    --------
-    events: np.recarray
-        Recarray of events
+def extract_relevant_sessions(experiment, sessions):
     """
-    if excluded_sessions is None:
-        return events
+        Given a list of sessions to include, undo the offsets for catFR and
+        PAL so the sessions can be looked up correctly in the r1.json file
+    """
+    if sessions is None:
+        return sessions
 
-    for session in excluded_sessions:
-        events = events[events.session != session]
+    elif experiment.find("PAL") != -1:
+        relevant_sessions = [(sess - 200) for sess in sessions if sess >= 200]
 
-    return events
+    elif experiment.find("cat") != -1:
+        relevant_sessions = [(sess - 100) for sess in sessions if (sess >= 100 and sess < 200)]
+
+    elif experiment.find("FR") != -1:
+        relevant_sessions = [sess for sess in sessions if sess < 100]
+
+    elif experiment.find("PS") != -1:
+        relevant_sessions = [sess for sess in sessions if sess < 100]
+
+    else:
+        raise RuntimeError("Only Fr/catFR/PAL session numbering with offsets is supported")
+    return relevant_sessions
 
 
 def update_subject(events):

--- a/ramutils/events.py
+++ b/ramutils/events.py
@@ -142,6 +142,7 @@ def clean_events(events, start_time=None, end_time=None, duration=None,
         raise RuntimeError('Event cleaning can only happen on single-experiment'
                            ' datasets')
     experiment = experiments[0]
+
     events = remove_negative_offsets(events)
 
     # Only for PS5 do we want to keep the practice list around so we can know
@@ -155,9 +156,6 @@ def clean_events(events, start_time=None, end_time=None, duration=None,
 
     events = remove_incomplete_lists(events)
     events = select_column_subset(events, all_relevant=True)
-
-    # TODO: Add remove_repetitions() function to get rid of any recall events
-    # that are just a repeated recall
 
     # separate_stim_events is called within the task-specific functions
     # because the columns to subset differs by task
@@ -187,6 +185,28 @@ def clean_events(events, start_time=None, end_time=None, duration=None,
 
     if return_stim_events:
         return events, stim_params
+
+    return events
+
+
+def remove_sessions(events, excluded_sessions):
+    """ Remove the requested sessions from the events
+
+    Parameters:
+    -----------
+    excluded_sessions: List[int]
+        List of session numbers to exclude. Convention is to start at 0 for FR, 100 for catFR, and 200 for PAL
+
+    Returns:
+    --------
+    events: np.recarray
+        Recarray of events
+    """
+    if excluded_sessions is None:
+        return events
+
+    for session in excluded_sessions:
+        events = events[events.session != session]
 
     return events
 

--- a/ramutils/events.py
+++ b/ramutils/events.py
@@ -50,7 +50,7 @@ def load_events(subject, experiment, file_type='all_events',
                                                "protocols",
                                                "r1.json"))
 
-    sessions_to_load = extract_relevant_sessions(experiment, sessions)
+    sessions_to_load = remove_session_number_offsets(experiment, sessions)
     if sessions_to_load is None:
         sessions_to_load = get_completed_sessions(subject, experiment,
                                                   rootdir=rootdir)
@@ -188,7 +188,7 @@ def clean_events(events, start_time=None, end_time=None, duration=None,
     return events
 
 
-def extract_relevant_sessions(experiment, sessions):
+def remove_session_number_offsets(experiment, sessions):
     """
         Given a list of sessions to include, undo the offsets for catFR and
         PAL so the sessions can be looked up correctly in the r1.json file

--- a/ramutils/pipelines/ramulator_config.py
+++ b/ramutils/pipelines/ramulator_config.py
@@ -44,7 +44,7 @@ def make_ramulator_config(subject, experiment, paths, stim_params,
                           exp_params=None, vispath=None, extended_blanking=True,
                           localization=0, montage=0, default_surface_area=0.001,
                           trigger_pairs=None, use_common_reference=False,
-                          use_classifier_excluded_leads=False, excluded_sessions=None):
+                          use_classifier_excluded_leads=False):
     """ Generate configuration files for a Ramulator experiment
 
     Parameters
@@ -76,8 +76,6 @@ def make_ramulator_config(subject, experiment, paths, stim_params,
         referencing.
     use_classifier_excluded_leads: bool
         Use contents of classifier_excluded_leads.txt to exclude channels from classifier training
-    excluded_sessions: List[int]
-        Sessions to exclude from classifier training and config generation
 
     Returns
     -------
@@ -151,7 +149,7 @@ def make_ramulator_config(subject, experiment, paths, stim_params,
                            "implemented")
     kwargs = exp_params.to_dict()
 
-    all_task_events = build_training_data(subject, experiment, paths, excluded_sessions=excluded_sessions, **kwargs)
+    all_task_events = build_training_data(subject, experiment, paths, **kwargs)
 
     powers, final_task_events = compute_normalized_powers(all_task_events,
                                                           bipolar_pairs=ec_pairs,

--- a/ramutils/pipelines/ramulator_config.py
+++ b/ramutils/pipelines/ramulator_config.py
@@ -44,7 +44,7 @@ def make_ramulator_config(subject, experiment, paths, stim_params,
                           exp_params=None, vispath=None, extended_blanking=True,
                           localization=0, montage=0, default_surface_area=0.001,
                           trigger_pairs=None, use_common_reference=False,
-                          use_classifier_excluded_leads=False):
+                          use_classifier_excluded_leads=False, excluded_sessions=None):
     """ Generate configuration files for a Ramulator experiment
 
     Parameters
@@ -76,6 +76,8 @@ def make_ramulator_config(subject, experiment, paths, stim_params,
         referencing.
     use_classifier_excluded_leads: bool
         Use contents of classifier_excluded_leads.txt to exclude channels from classifier training
+    excluded_sessions: List[int]
+        Sessions to exclude from classifier training and config generation
 
     Returns
     -------
@@ -149,11 +151,8 @@ def make_ramulator_config(subject, experiment, paths, stim_params,
                            "implemented")
     kwargs = exp_params.to_dict()
 
-    all_task_events = build_training_data(subject, experiment, paths, **kwargs)
+    all_task_events = build_training_data(subject, experiment, paths, excluded_sessions=excluded_sessions, **kwargs)
 
-    # FIXME: If PTSA is updated to not remove events behind this scenes, this
-    # won't be necessary. Or, if we can remove bad events before passing to
-    # compute powers, then we won't have to catch the events
     powers, final_task_events = compute_normalized_powers(all_task_events,
                                                           bipolar_pairs=ec_pairs,
                                                           **kwargs)

--- a/ramutils/pipelines/report.py
+++ b/ramutils/pipelines/report.py
@@ -205,7 +205,7 @@ def generate_data_for_nonstim_report(subject, experiment, sessions,
                                      joint_report, paths, ec_pairs,
                                      used_pair_mask, excluded_pairs,
                                      final_pairs, pairs_metadata_table,
-                                     all_events,  **kwargs):
+                                     all_events, **kwargs):
     """ Report generation sub-pipeline that is shared by all nonstim reports """
     repetition_ratio_dict = {}
     if joint_report or (experiment == 'catFR1'):

--- a/ramutils/pipelines/report.py
+++ b/ramutils/pipelines/report.py
@@ -11,7 +11,7 @@ from ramutils.montage import get_classifier_excluded_leads
 def make_report(subject, experiment, paths, joint_report=False,
                 retrain=False, stim_params=None, exp_params=None,
                 sessions=None, vispath=None, rerun=False,
-                trigger_electrode=None, use_classifier_excluded_leads=False, excluded_sessions=None):
+                trigger_electrode=None, use_classifier_excluded_leads=False):
     """Run a report.
 
     Parameters
@@ -43,8 +43,6 @@ def make_report(subject, experiment, paths, joint_report=False,
         in PS5
     use_classifier_excluded_leads: bool
         Use contents of classifier_excluded_leads.txt to exclude channels from classifier training
-    excluded_sessions: Lis[int]
-        List of sessions to exclude from classifier training
 
     Returns
     -------
@@ -138,7 +136,6 @@ def make_report(subject, experiment, paths, joint_report=False,
                                              used_pair_mask, excluded_pairs,
                                              final_pairs, pairs_metadata_table,
                                              all_events,
-                                             excluded_sessions=excluded_sessions,
                                              **kwargs)
     elif experiment.find("PS5") != -1:
         session_summaries, math_summaries, \
@@ -160,7 +157,6 @@ def make_report(subject, experiment, paths, joint_report=False,
                                           used_pair_mask, final_pairs,
                                           pairs_metadata_table, all_events,
                                           task_events, stim_data,
-                                          excluded_sessions=excluded_sessions,
                                           **kwargs)
 
     output = save_all_output(subject, experiment, session_summaries,
@@ -209,7 +205,7 @@ def generate_data_for_nonstim_report(subject, experiment, sessions,
                                      joint_report, paths, ec_pairs,
                                      used_pair_mask, excluded_pairs,
                                      final_pairs, pairs_metadata_table,
-                                     all_events, excluded_sessions=None, **kwargs):
+                                     all_events,  **kwargs):
     """ Report generation sub-pipeline that is shared by all nonstim reports """
     repetition_ratio_dict = {}
     if joint_report or (experiment == 'catFR1'):
@@ -225,7 +221,6 @@ def generate_data_for_nonstim_report(subject, experiment, sessions,
                                           experiment,
                                           paths,
                                           sessions=sessions,
-                                          excluded_sessions=excluded_sessions,
                                           **kwargs)
 
     powers, final_task_events = compute_normalized_powers(
@@ -305,8 +300,7 @@ def generate_data_for_stim_report(subject, experiment, joint_report, retrain,
                                   paths, ec_pairs, excluded_pairs,
                                   used_pair_mask, final_pairs,
                                   pairs_metadata_table, all_events,
-                                  task_events, stim_data, excluded_sessions=None,
-                                  **kwargs):
+                                  task_events, stim_data, **kwargs):
     """ Report generation sub-pipeline shared by all stim reports """
     series_num = extract_experiment_series(experiment)
     # FR2 does not have STIM_OFF events, so until we can identify them more
@@ -334,7 +328,6 @@ def generate_data_for_stim_report(subject, experiment, joint_report, retrain,
     retrained_classifier = None
     if retrain or any([classifier is None for classifier in used_classifiers]):
         training_events = build_training_data(subject, experiment, paths,
-                                              excluded_sessions=excluded_sessions,
                                               **kwargs).compute()
 
         training_powers, final_training_events = compute_normalized_powers(

--- a/ramutils/reports/generate.py
+++ b/ramutils/reports/generate.py
@@ -64,11 +64,6 @@ class ReportGenerator(object):
         self.subject = extract_subject(self.session_summaries[0].events)
         self.hmm_results = hmm_results
 
-        # PS has not math summaries, so only check for non-PS experiments
-        if all(['PS' not in exp for exp in self.experiments]):
-            if len(session_summaries) != len(math_summaries):
-                raise ValueError("Summaries contain different numbers of sessions")
-
         self._env = Environment(
             loader=PackageLoader('ramutils.reports', 'templates'),
         )

--- a/ramutils/tasks/events.py
+++ b/ramutils/tasks/events.py
@@ -7,7 +7,7 @@ from ramutils.events import get_repetition_ratio_dict as \
     get_repetition_ratio_dict_core
 from ramutils.events import get_post_stim_events_mask as \
     get_post_stim_events_mask_core
-from ramutils.events import remove_practice_lists, remove_sessions
+from ramutils.events import remove_practice_lists
 from ramutils.tasks import task
 from ramutils.utils import extract_experiment_series
 

--- a/ramutils/tasks/events.py
+++ b/ramutils/tasks/events.py
@@ -39,13 +39,12 @@ def subset_events(events, mask):
 
 
 @task()
-def build_training_data(subject, experiment, paths, sessions=None, excluded_sessions=None, **kwargs):
+def build_training_data(subject, experiment, paths, sessions=None, **kwargs):
     """ Construct the set of events needed for classifier training """
     if "PAL" in experiment:
         pal_events = load_events(subject, "PAL1", sessions=sessions,
                                  rootdir=paths.root)
         cleaned_pal_events = clean_events(pal_events)
-        cleaned_pal_events = remove_sessions(cleaned_pal_events, excluded_sessions)
 
     if (("FR" in experiment) and kwargs['combine_events']) or \
             ("PAL" in experiment and kwargs['combine_events']):
@@ -70,7 +69,6 @@ def build_training_data(subject, experiment, paths, sessions=None, excluded_sess
 
         free_recall_events = concatenate_events_across_experiments(
             [cleaned_fr_events, cleaned_catfr_events], cat=True)
-        free_recall_events = remove_sessions(free_recall_events, excluded_sessions)
 
     elif "FR" in experiment and not kwargs['combine_events']:
         free_recall_events = load_events(subject, experiment, sessions=sessions,
@@ -81,12 +79,10 @@ def build_training_data(subject, experiment, paths, sessions=None, excluded_sess
                                           duration=kwargs['empty_epoch_duration'],
                                           pre=kwargs['pre_event_buf'],
                                           post=kwargs['post_event_buf'])
-        free_recall_events = remove_sessions(free_recall_events, excluded_sessions)
 
     if ("PAL" in experiment) and kwargs['combine_events']:
         all_task_events = concatenate_events_across_experiments([
             free_recall_events, cleaned_pal_events])
-        all_task_events = remove_sessions(all_task_events, excluded_sessions)
 
     elif ("PAL" in experiment) and not kwargs['combine_events']:
         all_task_events = cleaned_pal_events

--- a/ramutils/test/test_cli.py
+++ b/ramutils/test/test_cli.py
@@ -153,7 +153,7 @@ class TestCreateReports:
         ('R1001P', 'FR1', None, False, False),
         ('R1354E', 'FR1', [0], False, False),
         ('R1354E', 'FR1', [0, 1], False, False),
-        ('R1354E', 'CatFR1', [0], False, False),
+        ('R1354E', 'CatFR1', [100], False, False),
         ('R1354E', 'FR1', None, True, False),
         ('R1345D', 'FR1', None, False, False),
         ('R1374T', 'CatFR1', None, False, False),
@@ -193,7 +193,7 @@ class TestCreateReports:
     @pytest.mark.parametrize('subject, experiment, sessions', [
         ('R1111M', 'FR2', [0]),
         ('R1154D', 'FR3', [0]),
-        ('R1374T', 'CatFR5', [0]),
+        ('R1374T', 'CatFR5', [100]),
         ('R1345D', 'FR5', [0]),
         ('R1374T', 'PS4_CatFR5', [3]),
         ('R1001P', 'FR2', [0]),

--- a/ramutils/test/test_events.py
+++ b/ramutils/test/test_events.py
@@ -284,8 +284,8 @@ class TestEvents:
         ('PAL1', [0, 1, 100, 102, 203], [3]),
         ('PS', [0, 1, 100, 102, 203], [0, 1])
     ])
-    def test_extract_relevant_sessions(self, experiment, session_list, exp_sessions):
-        extracted_sessions = extract_relevant_sessions(experiment, session_list)
+    def test_remove_session_number_offsets(self, experiment, session_list, exp_sessions):
+        extracted_sessions = remove_session_number_offsets(experiment, session_list)
         assert extracted_sessions == exp_sessions
         return
 

--- a/ramutils/test/test_events.py
+++ b/ramutils/test/test_events.py
@@ -42,7 +42,7 @@ class TestEvents:
         ('R1354E', 'FR1', None),
         ('R1354E', 'FR1', [1]),
         ('R1354E', 'catFR1', None),
-        ('R1354E', 'catFR1', [1])
+        ('R1354E', 'catFR1', [101])
     ])
     def test_load_events(self, subject, experiment, sessions):
         events = load_events(subject, experiment, sessions=sessions,
@@ -276,6 +276,17 @@ class TestEvents:
 
     def test_extract_stim_and_post_stim_masks(self):
         # TODO: Fill in with comparison to legacy outputs
+        return
+
+    @pytest.mark.parametrize("experiment, session_list, exp_sessions", [
+        ('FR1', [0, 1, 100, 102, 203], [0, 1]),
+        ('catfr1', [0, 1, 100, 102, 203], [0, 2]),
+        ('PAL1', [0, 1, 100, 102, 203], [3]),
+        ('PS', [0, 1, 100, 102, 203], [0, 1])
+    ])
+    def test_extract_relevant_sessions(self, experiment, session_list, exp_sessions):
+        extracted_sessions = extract_relevant_sessions(experiment, session_list)
+        assert extracted_sessions == exp_sessions
         return
 
     @pytest.mark.rhino


### PR DESCRIPTION
Updated how the existing sessions parameter is used to allow for explicitly passed sessions to implicitly exclude sessions. catFR sessions must be offset by 100 and PAL must be offset by 200. FR and PS start at 0