### PR TITLE
Quickfixes

### DIFF
--- a/ramutils/pipelines/aggregated_report.py
+++ b/ramutils/pipelines/aggregated_report.py
@@ -22,19 +22,17 @@ def make_aggregated_report(subjects=None, experiments=None, sessions=None, fit_m
         for experiment in experiments:
             exp_subjects = find_subjects(experiment, paths.root)
             for subject in exp_subjects:
-                target_selection_table, classifier_evaluation_results, \
-                session_summaries, math_summaries, hmm_results = \
-                    load_existing_results(subject, experiment, sessions, True,
-                                          paths.data_db, rootdir=paths.root).compute()
-                if all([val is None for val in [target_selection_table,
-                                                classifier_evaluation_results,
-                                                session_summaries, math_summaries]]):
+                pre_built_results = load_existing_results(subject, experiment, sessions, True,
+                                                          paths.data_db, rootdir=paths.root).compute()
+                if all([val is None for val in [pre_built_results['classifier_evaluation_results'],
+                                                pre_built_results['session_summaries'],
+                                                pre_built_results['math_summaries']]]):
                     logger.warning('Unable to find underlying data for {}, experiment {}'.format(subject, experiment))
                     continue
 
-                all_classifier_evaluation_results.extend(classifier_evaluation_results)
-                all_session_summaries.extend(session_summaries)
-                all_math_summaries.extend(math_summaries)
+                all_classifier_evaluation_results.extend(pre_built_results['classifier_evaluation_results'])
+                all_session_summaries.extend(pre_built_results['session_summaries'])
+                all_math_summaries.extend(pre_built_results['math_summaries'])
         subject = 'combined'
         experiment = "_".join(experiments)
 
@@ -42,20 +40,19 @@ def make_aggregated_report(subjects=None, experiments=None, sessions=None, fit_m
     elif subjects is not None and experiments is not None and sessions is None:
         for subject in subjects:
             for experiment in experiments:
-                target_selection_table, classifier_evaluation_results, \
-                session_summaries, math_summaries, hmm_results = \
-                    load_existing_results(subject, experiment, sessions, True,
-                                          paths.data_db, rootdir=paths.root).compute()
-
-                if all([val is None for val in [target_selection_table,
-                                                classifier_evaluation_results,
-                                                session_summaries, math_summaries]]):
+                pre_built_results = load_existing_results(subject, experiment, sessions, True,
+                                                     paths.data_db, rootdir=paths.root).compute()
+                # Check if only None values were returned. Processing will continue
+                # undeterred
+                if all([val is None for val in [pre_built_results['classifier_evaluation_results'],
+                                                pre_built_results['session_summaries'],
+                                                pre_built_results['math_summaries']]]):
                     logger.warning('Unable to find underlying data for {}, experiment {}'.format(subject, experiment))
                     continue
 
-                all_classifier_evaluation_results.extend(classifier_evaluation_results)
-                all_session_summaries.extend(session_summaries)
-                all_math_summaries.extend(math_summaries)
+                all_classifier_evaluation_results.extend(pre_built_results['classifier_evaluation_results'])
+                all_session_summaries.extend(pre_built_results['session_summaries'])
+                all_math_summaries.extend(pre_built_results['math_summaries'])
         subject = '_'.join(subjects)
         experiment = "_".join(experiments)
 
@@ -66,18 +63,16 @@ def make_aggregated_report(subjects=None, experiments=None, sessions=None, fit_m
         subject = subjects[0]
         experiment = experiments[0]
 
-        target_selection_table, classifier_evaluation_results, \
-        session_summaries, math_summaries, hmm_results = \
-            load_existing_results(subject, experiment, sessions, True,
-                                  paths.data_db, rootdir=paths.root).compute()
-
-        if all([val is None for val in [target_selection_table,
-                                        classifier_evaluation_results,
-                                        session_summaries, math_summaries]]):
+        pre_built_results = load_existing_results(subject, experiment, sessions, True,
+                                                  paths.data_db, rootdir=paths.root).compute()
+        if all([val is None for val in [pre_built_results['classifier_evaluation_results'],
+                                        pre_built_results['session_summaries'],
+                                        pre_built_results['math_summaries']]]):
             logger.warning('Unable to find underlying data for {}, experiment {}'.format(subject, experiment))
-        all_classifier_evaluation_results.extend(classifier_evaluation_results)
-        all_session_summaries.extend(session_summaries)
-        all_math_summaries.extend(math_summaries)
+
+        all_classifier_evaluation_results.extend(pre_built_results['classifier_evaluation_results'])
+        all_session_summaries.extend(pre_built_results['session_summaries'])
+        all_math_summaries.extend(pre_built_results['math_summaries'])
 
     else:
         raise RuntimeError('The requested type of aggregation is not currently supported')

--- a/ramutils/tasks/misc.py
+++ b/ramutils/tasks/misc.py
@@ -295,6 +295,7 @@ def load_existing_results(subject, experiment, sessions, stim_report, db_loc,
 
             saved_results['session_summaries'] = session_summaries
             saved_results['math_summaries'] = math_summaries
+            saved_results['classifier_evaluation_results'] = classifier_evaluation_results
 
         else:
             return saved_results

--- a/ramutils/tasks/misc.py
+++ b/ramutils/tasks/misc.py
@@ -10,7 +10,7 @@ except ImportError:
     from urlparse import urlparse
 
 from ptsa.data.readers import JsonIndexReader
-from ramutils.io import load_results, store_results
+from ramutils.io import store_results
 from ramutils.utils import get_session_str
 
 from ._wrapper import task
@@ -54,6 +54,50 @@ def save_all_output(subject, experiment, session_summaries, math_summaries,
                     classifier_evaluation_results, save_location,
                     retrained_classifier=None, target_selection_table=None,
                     behavioral_results=None):
+    """ Save all required output necessary to re-generate a report
+
+    Parameters:
+    -----------
+    subject: str
+        Subject ID
+    experiment: str
+        Experiment name
+    session_summaries: List
+        List of SessionSummary derived objects
+    math_summaries: List
+        List of MathSummary objects
+    classifier_evaluation_results: List
+        List of ClassifierSummary objects
+    save_location: str
+        Destination for data to be saved. Typically in
+        /scratch/report_database/ on RHINO
+    retrained_classifier: ClassifierContainer
+        Serialized representation of the retrained classifier
+    target_selection_table pd.DataFrame
+        DataFrame representation of the target selection table, formerly known
+        as the subsequent memory effect table
+    behavioral_results: dict
+        Keys are the behavioral effect model type (stim list, stim item, etc.)
+        and values are the traces from estimating those models
+
+    Returns
+    -------
+    results_files: dict
+        Dictionary whose keys are the names of statically-produced plots and
+        values are encoded versions of those images. These are used to embed
+        the static plots in the html reports during report generation
+
+    Notes
+    -----
+    All output files are of the format {subject}_{experiment}_{session}_{data_type}.{file_type}
+    where data_type is a generic name for the type of data being saved. The following data types
+    map to a summary object:
+
+    * sessions_summary: :class:`ramutils.reports.summary.SessionSummary`
+    * math_summary: :class:`ramutils.reports.summary.MathSummary`
+    * classifier_[tag]: :class:`ramutils.reports.summary.ClassifierSummary`
+
+    """
 
     result_files = {}
 
@@ -126,6 +170,38 @@ def save_all_output(subject, experiment, session_summaries, math_summaries,
 @task(cache=False)
 def load_existing_results(subject, experiment, sessions, stim_report, db_loc,
                           rootdir='/'):
+    """ Load previously-saved data creating during report generation
+
+    Parameters:
+    -----------
+    subject: str
+        Subject ID
+    experiment: str
+        Experiment ID
+    sessions: list or None
+        If none, then sessions are looked up from r1.json for the given subject and experiment.
+    stim_report: bool
+        Indicator for if the requested data is associated with a stim report
+    db_loc: str
+        Report database location relative to rootdir
+    rootdir: str
+        RHINO mount point or root directory
+
+    Returns:
+    --------
+    saved_results: dict
+        Mirrors the input to save_all_output
+
+    """
+
+    saved_results = {
+        'target_selection_table': None,
+        'classifier_evaluation_results': None,
+        'session_summaries': None,
+        'math_summaries': None,
+        'hmm_results': None
+    }
+
     # Repetition ratio dictionary optional
     # Cases: PS, stim, non-stim
     subject_experiment = "_".join([subject, experiment])
@@ -144,6 +220,8 @@ def load_existing_results(subject, experiment, sessions, stim_report, db_loc,
                 base_output_format.format(session=session_str,
                                           data_type='target_selection_table',
                                           file_type='csv'))
+            saved_results['target_selection_table'] = target_selection_table
+
             encoding_classifier_summary = ClassifierSummary.from_hdf(
                 base_output_format.format(session=session_str,
                                           data_type='classifier_Encoding',
@@ -154,6 +232,8 @@ def load_existing_results(subject, experiment, sessions, stim_report, db_loc,
                                           file_type='h5'))
             classifier_evaluation_results = [encoding_classifier_summary,
                                              joint_classifier_summary]
+            saved_results['classifier_evaluation_results'] = classifier_evaluation_results
+
             session_summaries, math_summaries = [], []
             for session in sessions:
                 math_summary = MathSummary.from_hdf(
@@ -172,6 +252,9 @@ def load_existing_results(subject, experiment, sessions, stim_report, db_loc,
                                               data_type='session_summary',
                                               file_type='h5'))
                 session_summaries.append(session_summary)
+
+            saved_results['session_summaries'] = session_summaries
+            saved_results['math_summaries'] = math_summaries
 
         elif stim_report and 'PS' not in experiment:
             classifier_evaluation_results, math_summaries, session_summaries = [], [], []
@@ -210,14 +293,16 @@ def load_existing_results(subject, experiment, sessions, stim_report, db_loc,
                             encoded_image = base64.b64encode(f.read()).replace(b"\n", b"").decode()
                         hmm_results[name] = encoded_image
 
+            saved_results['session_summaries'] = session_summaries
+            saved_results['math_summaries'] = math_summaries
+
         else:
-            return None, None, None, None, None
+            return saved_results
 
     except (IOError, OSError, AssertionError):
         logger.warning('Not all underlying data could be found for the '
                        'requested report, building from scratch instead.')
-        return None, None, None, None, None
+        return saved_results
 
-    return target_selection_table, classifier_evaluation_results, \
-           session_summaries, math_summaries, hmm_results
+    return saved_results
 

--- a/ramutils/tasks/reports.py
+++ b/ramutils/tasks/reports.py
@@ -42,4 +42,4 @@ def build_static_report(subject, experiment, session_summaries, math_summaries,
         with open(final_destination, 'w') as f:
             f.write(report)
 
-    return report
+    return True

--- a/ramutils/tasks/reports.py
+++ b/ramutils/tasks/reports.py
@@ -42,4 +42,4 @@ def build_static_report(subject, experiment, session_summaries, math_summaries,
         with open(final_destination, 'w') as f:
             f.write(report)
 
-    return True
+    return final_destination

--- a/ramutils/test/tasks/test_misc.py
+++ b/ramutils/test/tasks/test_misc.py
@@ -15,18 +15,19 @@ datafile = functools.partial(resource_filename,
 @pytest.mark.rhino
 def test_build_report_from_cached_results():
 
-    target_selection_table, classifier_summaries, session_summaries, \
-    math_summaries, hmm_results = load_existing_results(
+    prior_results = load_existing_results(
         'R1354E', 'FR1', [1], False, datafile('input/report_db'),
         datafile('')).compute()
 
-    assert session_summaries is not None
-    assert classifier_summaries is not None
-    assert target_selection_table is not None
+    assert prior_results['session_summaries'] is not None
+    assert prior_results['classifier_evaluation_results'] is not None
+    assert prior_results['target_selection_table'] is not None
 
-    report = build_static_report('R1354E', 'FR1', session_summaries,
-                                 math_summaries, target_selection_table,
-                                 classifier_summaries,
+    report = build_static_report('R1354E', 'FR1',
+                                 prior_results['session_summaries'],
+                                 prior_results['math_summaries'],
+                                 prior_results['target_selection_table'],
+                                 prior_results['classifier_evaluation_results'],
                                  datafile('output/')).compute()
 
     assert report is not None
@@ -38,13 +39,11 @@ def test_build_report_from_cached_results():
         os.remove(f)
 
     # Check that non-existent data returns all None values
-    target_selection_table, classifier_summaries, session_summaries, \
-    math_summaries, hmm_results = load_existing_results(
+    prior_results = load_existing_results(
         'R1345D', 'FR1', [1], False, datafile('input/report_db'),
         datafile('')).compute()
 
-    results = [target_selection_table, classifier_summaries, session_summaries,
-               math_summaries, hmm_results]
+    results = [v for k,v in prior_results.items()]
 
     assert all([r is None for r in results])
     return


### PR DESCRIPTION
Returns the path of the report rather than the report data. This was a bug that I introduced because the full data while I was debugging and forgot to put it back. The other change is based on the code review. load_existing_results() returns a dictionary of loaded data rather than a list. The make_report() function used a named tuple to keep track of this data which cleans up the code a bit.