### PR TITLE
exclude first 3 lists from hmm models

### DIFF
--- a/ramutils/tasks/behavioral_analysis.py
+++ b/ramutils/tasks/behavioral_analysis.py
@@ -44,6 +44,8 @@ def estimate_effects_of_stim(subject, experiment, stim_session_summaries):
     df['session_idx'] = df.groupby(by=['subject', 'experiment', 'session']).grouper.group_info[0]
     df["serialpos"] = df["serialpos"] - (df["serialpos"].min())
 
+    df = df[df["list"] > 3] # drop the first 3 lists since they are not technically part of the experiment
+
     # Turn list into a % session completed variable to that subjects who
     # complete only partial sessions can still be compared to full sessions
     df["list"] = ((df["list"] - (df["list"].min())) /


### PR DESCRIPTION
Another trivial PR. Ensures that first three lists are not included when estimating behavioral effects of stim