### PR TITLE
Fix how transition times are calculated

### DIFF
--- a/ramutils/reports/summary.py
+++ b/ramutils/reports/summary.py
@@ -652,11 +652,14 @@ class CatFRSessionSummary(FRSessionSummary):
 
         self.repetition_ratios = repetition_ratio_dict
 
-        # Calculate between and within IRTs based on non-intrusion recall
-        # events
-        catfr_events = events[(events.experiment == 'catFR1') &
-                              (events.type == 'REC_EVENT')]
-        cat_recalled_events = catfr_events[catfr_events.recalled == 1]
+
+        # Calculate between and within IRTs based on the REC_WORD events as found in all_events.json
+        # Exclude all intrusions so that a transition between an intrusion and a recall will not be
+        # counted towards either within or between times.
+        catfr_events = raw_events[(raw_events.experiment == 'catFR1') &
+                                  (raw_events.type == 'REC_WORD') &
+                                  (raw_events.intrusion == 0)]
+        cat_recalled_events = catfr_events[(catfr_events.recalled == 1)]
         irt_within_cat = []
         irt_between_cat = []
         for session in np.unique(catfr_events.session):

--- a/ramutils/reports/summary.py
+++ b/ramutils/reports/summary.py
@@ -652,8 +652,10 @@ class CatFRSessionSummary(FRSessionSummary):
 
         self.repetition_ratios = repetition_ratio_dict
 
-        # Calculate between and within IRTs based on events
-        catfr_events = events[events.experiment == 'catFR1']
+        # Calculate between and within IRTs based on non-intrusion recall
+        # events
+        catfr_events = events[(events.experiment == 'catFR1') &
+                              (events.type == 'REC_EVENT')]
         cat_recalled_events = catfr_events[catfr_events.recalled == 1]
         irt_within_cat = []
         irt_between_cat = []

--- a/ramutils/test/reports/test_summary.py
+++ b/ramutils/test/reports/test_summary.py
@@ -204,10 +204,11 @@ class TestCatFRSessionSummary:
     def setup_class(cls):
         cls.summary = CatFRSessionSummary()
         events = fr5_events()
+        raw_events = fr5_events()
         pairs = bipolar_pairs()
         excluded = excluded_pairs()
         powers = normalized_powers()
-        cls.summary.populate(events, pairs, excluded, powers)
+        cls.summary.populate(events, pairs, excluded, powers, raw_events=raw_events)
 
     def test_to_dataframe(self):
         df = self.summary.to_dataframe()


### PR DESCRIPTION
Bugfix to how inter-item response times were calculated for between and within category transitions. Previously, WORD events were included in addition to REC_WORD, which resulted in inflated IRTs because the time between encoding and recall was included