### PR TITLE
IRT Fix #2

### DIFF
--- a/ramutils/reports/summary.py
+++ b/ramutils/reports/summary.py
@@ -656,9 +656,10 @@ class CatFRSessionSummary(FRSessionSummary):
         # Calculate between and within IRTs based on the REC_WORD events as found in all_events.json
         # Exclude all intrusions so that a transition between an intrusion and a recall will not be
         # counted towards either within or between times.
-        catfr_events = raw_events[(raw_events.experiment == 'catFR1') &
-                                  (raw_events.type == 'REC_WORD') &
-                                  (raw_events.intrusion == 0)]
+        catfr_events = events[(events.experiment == 'catFR1') &
+                              (events.type == 'REC_EVENT') &
+                              (events.intrusion == 0) &
+                              (events.recalled == 1)] # recalled == 0 indicates a baseline recall event
         cat_recalled_events = catfr_events[(catfr_events.recalled == 1)]
         irt_within_cat = []
         irt_between_cat = []


### PR DESCRIPTION
There is a better way to do this that is less error prone. The other method let to the long-running tests failing because the all_events recarray is not normalized so  "category_num" was not found for FR1 events in the joint reports. This alternative method uses the normalized task events instead and is equivalent to the other method, but doesn't require trying to additional manipulation to the raw_events structure