### PR TITLE
Code refactor to avoid weird segfault

### DIFF
--- a/demos/report_generation.py
+++ b/demos/report_generation.py
@@ -6,18 +6,16 @@ from ramutils.pipelines.report import make_report
 
 from ramutils.tasks import memory
 
-memory.cachedir = "/Users/zduey/tmp/"
+memory.cachedir = "~"
 
 
-subject = 'R1401J'
-rhino = os.path.expanduser('/Volumes/rhino')
 
 paths = FilePaths(
-    root='/Volumes/RHINO/',
+    root='/',
     dest='/scratch/zduey/',
     data_db='/scratch/zduey/'
 )
 
 params = FRParameters()
-make_report(subject, "FR1", paths, exp_params=params, stim_params=None,
-            joint_report=True, rerun=True, sessions=[0, 1, 100, 102])
+make_report("R1001P", "FR1", paths, exp_params=params, stim_params=None,
+            joint_report=False, rerun=False, sessions=None)

--- a/ramutils/reports/generate.py
+++ b/ramutils/reports/generate.py
@@ -264,15 +264,6 @@ class ReportGenerator(object):
             }
             plot_data['tags'] = [
                 classifier.id for classifier in self.classifier_summaries],
-            plot_data['activation'] = {
-                'weights': list(itertools.chain([classifier.classifier_activation_by_region.tolist()
-                                                 for classifier in self.classifier_summaries])),
-                'freqs': list(itertools.chain([classifier.frequencies.tolist()
-                                               for classifier in self.classifier_summaries])),
-                'regions': list(itertools.chain([classifier.regions
-                                                 for classifier in self.classifier_summaries])),
-                'names': [classifier.tag for classifier in self.classifier_summaries]
-            }
 
         return json.dumps(plot_data)
 

--- a/ramutils/reports/static/plots.js
+++ b/ramutils/reports/static/plots.js
@@ -274,7 +274,7 @@ var ramutils = (function (mod, Plotly) {
     * @param{Array} weights - classfier weights
     * @param{Array} freqs - frequencies used
     */
-    plotClassifierWeights: function(weights,freqs,labels,names){
+    plotClassifierWeights: function(weights, freqs, labels, names){
 
         let data =[];
         let layout = {

--- a/ramutils/reports/summary.py
+++ b/ramutils/reports/summary.py
@@ -195,7 +195,7 @@ class ClassifierSummary(Schema):
         """
         if self._features is None:
             return np.array([])
-        return np.dot(np.cov(self._features,rowvar=False),self._coef.squeeze())
+        return np.dot(np.cov(self._features, rowvar=False), self._coef.squeeze())
 
     @property
     def classifier_activation_2d(self):

--- a/ramutils/reports/templates/classifier.html
+++ b/ramutils/reports/templates/classifier.html
@@ -60,11 +60,6 @@
       </caption>
     {% endif %}
   </table>
-  <figure>
-      <div id="classifier-weight-plot"></div>
-      <figcaption> Average classifier activation pattern by frequency and brain region.
-        {% if not stim %} <b>(Left)</b> encoding only classifier; <b>(Right)</b> joint classifier. {% endif %}</figcaption>
-  </figure>
 </div>
   <script>
     window.addEventListener('load', () => {
@@ -75,9 +70,6 @@
       let tercData = plot_data["tercile"];
       let tags = plot_data["tags"];
       ramutils.plots.plotClassifierPerformance(rocData.fpr, rocData.tpr, tercData.low, tercData.mid, tercData.high, tags);
-
-      let activation_data = plot_data["activation"]
-      ramutils.plots.plotClassifierWeights(activation_data.weights, activation_data.freqs, activation_data.regions, activation_data.names);
     });
   </script>
 </div>

--- a/ramutils/reports/templates/classifier.html
+++ b/ramutils/reports/templates/classifier.html
@@ -60,6 +60,11 @@
       </caption>
     {% endif %}
   </table>
+  <figure>
+      <div id="classifier-weight-plot"></div>
+      <figcaption> Average classifier activation pattern by frequency and brain region.
+        {% if not stim %} <b>(Left)</b> encoding only classifier; <b>(Right)</b> joint classifier. {% endif %}</figcaption>
+  </figure>
 </div>
   <script>
     window.addEventListener('load', () => {

--- a/ramutils/reports/templates/classifier.html
+++ b/ramutils/reports/templates/classifier.html
@@ -25,21 +25,21 @@
     </tr>
     </thead>
     <tbody>
-    {% for classifier in classifiers %}
+    {% for classifier in classifiers["metadata"] %}
       <tr>
-        <td>{{ classifier.id }}</td>
-        <td>{{ classifier.tag }}</td>
+        <td>{{ classifier['id'] }}</td>
+        <td>{{ classifier['tag'] }}</td>
         {% if stim %}
-        <td>{{ classifier.reloaded }}</td>
+        <td>{{ classifier['reloaded'] }}</td>
         {% endif %}
-        <td>{{ "{:.3f}".format(classifier.auc) }}</td>
-        {% if classifier.pvalue < 0.001 %}
+        <td>{{ "{:.3f}".format(classifier['auc']) }}</td>
+        {% if classifier['pvalue'] < 0.001 %}
           <td>&lt; 0.001</td>
         {% else %}
-          <td>{{ '{:.3f}'.format(classifier.pvalue) }}</td>
+          <td>{{ '{:.3f}'.format(classifier['pvalue']) }}</td>
         {% endif %}
-        <td>{{ "{:.3f}".format(classifier.median_classifier_output) }}</td>
-        <td>{{ "[{:.3f}, {:.3f}]".format(classifier.confidence_interval_median_classifier_output[0], classifier.confidence_interval_median_classifier_output[1]) }}</td>
+        <td>{{ "{:.3f}".format(classifier['median_classifier_output']) }}</td>
+        <td>{{ "[{:.3f}, {:.3f}]".format(classifier['median_lower_bound'], classifier['median_upper_bound'])}}</td>
       </tr>
     {% endfor %}
     </tbody>
@@ -60,13 +60,6 @@
       </caption>
     {% endif %}
   </table>
-  {% if classifiers[0].classifier_activation.any() %}
-  <figure>
-      <div id="classifier-weight-plot"></div>
-      <figcaption> Average classifier activation pattern by frequency and brain region.
-        {% if not stim %} <b>(Left)</b> encoding only classifier; <b>(Right)</b> joint classifier. {% endif %}</figcaption>
-  </figure>
-  {% endif %}
 </div>
   <script>
     window.addEventListener('load', () => {
@@ -77,17 +70,9 @@
       let tercData = plot_data["tercile"];
       let tags = plot_data["tags"];
       ramutils.plots.plotClassifierPerformance(rocData.fpr, rocData.tpr, tercData.low, tercData.mid, tercData.high, tags);
-      let weights=[];
-      let freqs = [];
-      let regions = [];
-      let names=  [];
-      {% for classifier in classifiers %}
-      weights.push({{ classifier.classifier_activation_by_region.tolist() }});
-      freqs.push({{ classifier.frequencies.tolist() }});
-      regions.push( {{ classifier.regions}} );
-      names.push('{{ classifier.tag }}' );
-      {% endfor %}
-      ramutils.plots.plotClassifierWeights(weights,freqs,regions,names);
+
+      let activation_data = plot_data["activation"]
+      ramutils.plots.plotClassifierWeights(activation_data.weights, activation_data.freqs, activation_data.regions, activation_data.names);
     });
   </script>
 </div>

--- a/ramutils/test/test_events.py
+++ b/ramutils/test/test_events.py
@@ -7,6 +7,7 @@ from pkg_resources import resource_filename
 from ramutils.events import *
 from sklearn.externals import joblib
 from ramutils.parameters import FRParameters
+from ramutils.utils import load_event_test_data
 
 datafile = functools.partial(resource_filename, 'ramutils.test.test_data')
 
@@ -128,13 +129,12 @@ class TestEvents:
         return
 
     @pytest.mark.rhino
-    def test_insert_baseline_retrieval_events(self):
+    def test_insert_baseline_retrieval_events(self, rhino_root):
         # This is just a regression test. There should be something more
         # comprehensive. This does not look like it would be using rhino, but
         # under the hood a sample of eeg data is loaded to determine the sample
         # rate
-        events = np.rec.array(
-            np.load(datafile("input/events/R1409D_pre_baseline_event_insertion_events.npy")))
+        events = load_event_test_data(datafile("input/events/R1409D_pre_baseline_event_insertion_events.npy"), rhino_root)
         params = FRParameters()
         final_events = insert_baseline_retrieval_events(events,
                                                         params.baseline_removal_start_time,
@@ -142,8 +142,7 @@ class TestEvents:
                                                         params.empty_epoch_duration,
                                                         params.pre_event_buf,
                                                         params.post_event_buf)
-        expected_events = np.rec.array(
-            np.load(datafile("input/events/R1409D_post_retrieval_baseline_event_insertion_events.npy")))
+        expected_events = load_event_test_data(datafile("input/events/R1409D_post_retrieval_baseline_event_insertion_events.npy"), rhino_root)
 
         assert len(final_events) == len(expected_events)
 


### PR DESCRIPTION
Test suite has been segfaulting when run from one of the worker nodes on RHINO. I was able to narrow down the issue to the final step where the report is generated. I thought it had to do with the feature plots, but it turned out to be related to the classifier summaries, which contain a lot more information than they used to. Passing large data to Jinja templates can lead to segfaults because of a bug in CPython (https://github.com/pallets/jinja/issues/784). Apparently this bug is fixed for python 3.7, but in the mean time we can avoid the issue by simply not passing the classifier summary objects to the template and  instead extracting the data before hand and just passing the minimal amount of information to the template. I am still not sure why this does not happen consistently across platforms. For example, the issue does not come up when running the tests from a Mac or from the head node. It only seems to occur from one of the worker nodes.