### PR TITLE
extend joint-reports for ICat/FR

### DIFF
--- a/ramutils/pipelines/report.py
+++ b/ramutils/pipelines/report.py
@@ -288,7 +288,7 @@ def generate_data_for_nonstim_report(subject, experiment, sessions,
                                      all_events, **kwargs):
     """ Report generation sub-pipeline that is shared by all nonstim reports """
     repetition_ratio_dict = {}
-    if joint_report or (experiment == 'catFR1'):
+    if (joint_report and (experiment in ['FR1', 'catFR1'])) or (experiment == 'catFR1'):
         repetition_ratio_dict = get_repetition_ratio_dict(paths)
 
     # This logic is very similar to what is done in config generation except


### PR DESCRIPTION
This commit extends the existing functionality for pooling FR1 and catFR1 sessions to pooling IFR1 and ICatFR1 sessions.